### PR TITLE
drivers: platform: maxim: max32665: Add uart pin mapping select in ua…

### DIFF
--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -263,6 +263,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
+	sys_map_t map;
 	mxc_uart_regs_t *uart_regs;
 	struct max_uart_init_param *eparam;
 	struct no_os_uart_desc *descriptor;
@@ -353,7 +354,22 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MAP_B);
+	switch (eparam->map) {
+	case UART_MAP_DEFAULT:
+		map = MAP_B;
+		break;
+	case UART_MAP_A:
+		map = MAP_A;
+		break;
+	case UART_MAP_B:
+		map = MAP_B;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, map);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;
@@ -381,7 +397,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8, MAP_B);
+	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8, map);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;

--- a/drivers/platform/maxim/max32665/maxim_uart.h
+++ b/drivers/platform/maxim/max32665/maxim_uart.h
@@ -56,10 +56,20 @@ enum max_uart_flow_ctrl {
 };
 
 /**
+ * @brief UART pin mapping select
+ */
+enum max_uart_pin_map {
+	UART_MAP_DEFAULT,
+	UART_MAP_A,
+	UART_MAP_B,
+};
+
+/**
  * @brief Aditional UART config parameters
  */
 struct max_uart_init_param {
 	enum max_uart_flow_ctrl flow;
+	enum max_uart_pin_map map;
 	mxc_gpio_vssel_t vssel;
 };
 


### PR DESCRIPTION
…rt extras.

Exposes uart pin map select through the max_uart_init_param. MAP_B is used for FTHR boards while MAP_A for EV kits.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
