### PR TITLE
Add support for LTM4686

### DIFF
--- a/doc/sphinx/source/drivers/ltm4686.rst
+++ b/doc/sphinx/source/drivers/ltm4686.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/ltm4686/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -98,6 +98,7 @@ POWER MANAGEMENT
    drivers/adp1050
    drivers/ltc2992
    drivers/ltc4296
+   drivers/ltm4686
    drivers/lt7170
    drivers/lt7182s
    drivers/lt8491

--- a/doc/sphinx/source/projects/ltm4686.rst
+++ b/doc/sphinx/source/projects/ltm4686.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/ltm4686/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -72,6 +72,7 @@ POWER MANAGEMENT
    projects/adp1050
    projects/dc2703a
    projects/ltc4296
+   projects/ltm4686
    projects/lt7170
    projects/lt7182s
    projects/lt8722

--- a/drivers/power/ltm4686/README.rst
+++ b/drivers/power/ltm4686/README.rst
@@ -1,0 +1,237 @@
+LTM4686 no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+`LTM4686 <https://www.analog.com/LTM4686>`_
+
+Overview
+--------
+
+The LTM4686 is a dual 10A (12A Peak) or single 20A (24A Peak) step-down µModule
+DC/DC regulator with 39ms turn-on time. It features remote configurability and
+telemetry-monitoring of power management parameters over PMBus.
+
+Applications
+------------
+
+LTM4686
+-------
+
+* System Optimization in Prototype and Production
+
+LTM4686 Device Configuration
+----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C) alongside other GPIO pins if needed in the
+specific application (depends on the way the device is used).
+
+The first API to be called is **ltm4686_init**. Make sure that it return 0,
+which means that the driver was initialized correctly.
+
+The initialization API uses the device descriptor and an initialization
+parameter. The initialization parameter contains the **chip_id** of the device 
+and the optional GPIO parameters for controlling POWER GOOD, RUN, FAULT and
+ALERT pins. Use of packet error checking and the external clock can also be
+configured in the parameter. These are defined in the header file of the driver.
+
+VOUT Configuration
+------------------
+
+The VOUT_COMMAND sets the output voltage, while the VOUT_MAX sets the upper
+limit on the commanded voltage. The output voltage and limit for each channel
+can be set using the **ltm4686_vout_value** API.
+
+The output voltage transition rate for each channel can be configured using the
+**ltm4686_vout_tr** API.
+
+Output voltage lower and higher margin can also be configured using the
+**ltm4686_vout_margin** API.
+
+The OPERATION command via the **ltm4686_set_operation** can be used to command
+the output voltage to be regulated at the high margin, low margin, or at the
+nominal VOUT_COMMAND. This can also be used to set a channel off.
+
+VIN Configuration
+-----------------
+
+VIN_ON and VIN_OFF command values sets the input voltage window at which power
+conversion will proceed. Both of which can be configured through the
+**ltm4686_set_vin** API.
+
+Status Configuration
+--------------------
+
+Statuses bytes/words of the device can be read using **ltm4686_read_status**
+API.
+
+Telemetry
+---------
+
+Measurements for each output channel can be read using the
+**ltm4686_read_value** API. Some telemetry values includes input/output voltage,
+input/output current, die temperature, and output power.
+
+Timing Configuration
+--------------------
+
+The TON_DELAY command sets the time from when a start condition is received
+until the output voltage starts to rise. The TON_RISE sets the time from the
+from the time the output starts to rise to the time the output enters the
+regulation band. The TOFF_DELAY command sets the time from when a stop condition
+is received until the output voltage starts to fall. The TOFF_FALL command sets
+the time from the end of the turn-off delay time until the output voltage is
+commanded to zero. These commands can be set using the **ltm4686_set_timing**
+API.
+
+PWM Configuration
+-----------------
+
+The PWM of each output channel can be set on forced continuous mode or on
+pulse skip mode. This can be set using the **ltm4686_pwm_mode** API.
+
+NVM commands
+------------
+
+The device has an internal EEPROM that saves the settings configured to the
+device even when power is removed. The **ltm4686_nvm_cmd** API allows the user
+to store, compare and restore user settings.
+
+Software Reset Configuration
+----------------------------
+
+Software Reset operation is available through **ltm4686_software_reset** API.
+
+LTM4686 Driver Initialization Example
+-------------------------------------
+
+.. code-block:: bash
+
+	struct ltm4686_dev *ltm4686_dev;
+        struct no_os_i2c_init_param ltm4686_i2c_ip = {
+                .device_id = I2C_DEVICE_ID,
+                .max_speed_hz = 100000,
+                .platform_ops = I2C_OPS,
+                .slave_address = LTM4686_PMBUS_ADDRESS,
+                .extra = I2C_EXTRA,
+        };
+
+        struct ltm4686_init_param ltm4686_ip = {
+                .i2c_init = &ltm4686_i2c_ip,
+                .external_clk_en = false,
+                .crc_en = true,
+        };
+	ret = ltm4686_init(&ltm4686_dev, &ltm4686_ip);
+	if (ret)
+		goto error;
+
+LTM4686 no-OS IIO support
+-------------------------
+
+The LTM4686 IIO driver comes on top of the LTM4686 driver and offers support
+for interfacing IIO clients through libiio.
+
+LTM4686 IIO Device Configuration
+--------------------------------
+
+Input Channel Attributes
+------------------------
+
+VIN0/IIN0/TEMP channels are the input channels of the LTM4686 IIO
+device and each of them has a total of two channel attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly to each specific channel using a priv``
+
+Output Channel Attributes
+-------------------------
+
+IOUT0/IOUT1 channels are two output channels with the following channel
+attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly to each specific channel using a priv``
+
+Meanwhile, VOUT0/VOUT1 channels are two output channels with a separate channel
+attributes. Each channel has eight attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly to each specific channel using a priv``
+* ``enable - state of the channel``
+* ``enable_available - list of available states for the channel``
+* ``vout_command - VOUT_COMMAND value of the channel output``
+* ``vout_max - VOUT_COMMAND value of the channel output``
+* ``vout_margin_low - VOUT_MARGIN_LOW value of the channel output``
+* ``vout_margin_high - VOUT_MARGIN_HIGH value of the channel output``
+
+Global Attributes
+-----------------
+
+The device has a total of seven global attributes:
+
+* ``vout_ov_fault_limit_0 - Output overvoltage fault limit for channel 0``
+* ``vout_ov_fault_limit_1 - Output overvoltage fault limit for channel 1``
+* ``vout_uv_fault_limit_0 - Output undervoltage fault limit for channel 0``
+* ``vout_uv_fault_limit_1 - Output undervoltage fault limit for channel 1``
+* ``ot_fault_limit - Overtemperature fault limit for both channels``
+* ``vin_ov_fault_limit - Input overvoltage fault limit for both channels``
+* ``vin_uv_warn_limit - Output undervoltage warning limit for both channels``
+
+Debug Attributes
+----------------
+
+The device has a total of 11 debug attributes:
+
+* ``status_vout_0 - VOUT status byte value of channel 0``
+* ``status_vout_1 - VOUT status byte value of channel 1``
+* ``status_iout_0 - IOUT status byte value of channel 0``
+* ``status_iout_1 - IOUT status byte value of channel 1``
+* ``status_input - INPUT status byte value of channel 0``
+* ``status_mfr_specific_0 - MFR_SPECIFIC status byte value of channel 0``
+* ``status_mfr_specific_1 - MFR_SPECIFIC status byte value of channel 1``
+* ``status_word_0 - Status word value of the channel 0``
+* ``status_word_1 - Status word value of the channel 1``
+* ``status_temperature - TEMPERATURE status byte value of the device``
+* ``status_cml - CML status byte value of the device``
+
+LTM4686 IIO Driver Initialization Example
+-----------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct ltm4686_iio_desc *ltm4686_iio_desc;
+	struct ltm4686_iio_desc_init_param ltm4686_iio_ip = {
+		.ltm4686_init_param = &ltm4686_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = ltm4686_iio_init(&ltm4686_iio_desc, &ltm4686_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ltm4686",
+			.dev = ltm4686_iio_desc,
+			.dev_descriptor = ltm4686_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ltm4686_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		return ret;
+
+	return iio_app_run(app);

--- a/drivers/power/ltm4686/iio_ltm4686.c
+++ b/drivers/power/ltm4686/iio_ltm4686.c
@@ -1,0 +1,1062 @@
+/***************************************************************************//**
+ *   @file   iio_ltm4686.c
+ *   @brief  Source file for the LTM4686 IIO Driver
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "ltm4686.h"
+#include "iio_ltm4686.h"
+
+#define LTM4686_IIO_REG_CHAN(reg, chan)			(reg | (chan << 8))
+#define LTM4686_IIO_REG(x)				(x & 0xFF)
+#define LTM4686_IIO_CHAN(x)				((x >> 8) & 0xFF)
+
+#define LTM4686_IIO_VOUT_CHAN_GROUP(inst)	LTM4686_IIO_VOUT_ ##inst## _CHAN, \
+					LTM4686_IIO_IOUT_ ##inst## _CHAN
+
+static const char *const ltm4686_enable_avail[2] = {
+	"Disabled", "Enabled"
+};
+
+enum lt7182s_iio_enable_type {
+	LT7182S_IIO_OUTPUT_ENABLE,
+	LT7182S_IIO_PULSE_ENABLE,
+	LT7182S_IIO_SYNC_ENABLE,
+};
+
+enum ltm4686_iio_chan_type {
+	LTM4686_IIO_VOUT_CHAN_GROUP(0),
+	LTM4686_IIO_VOUT_CHAN_GROUP(1),
+	LTM4686_IIO_VOUT_CHAN_GROUP(2),
+	LTM4686_IIO_VOUT_CHAN_GROUP(3),
+	LTM4686_IIO_VIN_CHAN,
+	LTM4686_IIO_IIN_CHAN,
+	LTM4686_IIO_TEMP_CHAN,
+};
+
+static struct iio_device ltm4686_iio_dev;
+static struct iio_device ltm4673_iio_dev;
+
+/**
+ * @brief Read register value.
+ * @param dev     - The iio device structure.
+ * @param reg	  - Register to read.
+ * @param readval - Read value.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int32_t ltm4686_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int ret;
+	uint8_t block[4] = {0};
+
+	switch (reg) {
+	case LTM4686_MFR_GPIO_PROPAGATE:
+		if (ltm4686->id == ID_LTM4673)
+			return ltm4686_read_byte(ltm4686, ltm4686->page,
+						 (uint8_t)reg,
+						 (uint8_t *)readval);
+		else
+			return ltm4686_read_word(ltm4686, ltm4686->page,
+						 (uint8_t)reg,
+						 (uint16_t *)readval);
+	case LTM4686_MFR_PWM_MODE:
+	case LTM4686_MFR_ADC_CONTROL:
+		if (ltm4686->id == ID_LTM4673)
+			return ltm4686_read_word(ltm4686, ltm4686->page,
+						 (uint8_t)reg,
+						 (uint16_t *)readval);
+		else
+			return ltm4686_read_byte(ltm4686, ltm4686->page,
+						 (uint8_t)reg,
+						 (uint8_t *)readval);
+
+	case LTM4686_VOUT_COMMAND:
+	case LTM4686_VOUT_MAX:
+	case LTM4686_VOUT_MARGIN_HIGH:
+	case LTM4686_VOUT_MARGIN_LOW:
+	case LTM4686_VOUT_TRANSITION_RATE:
+	case LTM4686_FREQUENCY_SWITCH:
+	case LTM4686_VIN_ON:
+	case LTM4686_VIN_OFF:
+	case LTM4686_VOUT_OV_FAULT_LIMIT:
+	case LTM4686_VOUT_OV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_FAULT_LIMIT:
+	case LTM4686_IOUT_OC_WARN_LIMIT:
+	case LTM4686_OT_FAULT_LIMIT:
+	case LTM4686_OT_WARN_LIMIT:
+	case LTM4686_VIN_UV_WARN_LIMIT:
+	case LTM4686_IIN_OC_WARN_LIMIT:
+	case LTM4686_TON_DELAY:
+	case LTM4686_TON_RISE:
+	case LTM4686_TON_MAX_FAULT_LIMIT:
+	case LTM4686_TOFF_DELAY:
+	case LTM4686_TOFF_FALL:
+	case LTM4686_TOFF_MAX_WARN_LIMIT:
+	case LTM4686_STATUS_WORD:
+	case LTM4686_READ_VIN:
+	case LTM4686_READ_IIN:
+	case LTM4686_READ_VOUT:
+	case LTM4686_READ_IOUT:
+	case LTM4686_READ_TEMPERATURE_1:
+	case LTM4686_READ_POUT:
+	case LTM4686_MFR_USER_DATA_00:
+	case LTM4686_MFR_USER_DATA_01:
+	case LTM4686_MFR_USER_DATA_02:
+	case LTM4686_MFR_USER_DATA_03:
+	case LTM4686_MFR_CHAN_CONFIG:
+	case LTM4686_MFR_CONFIG_ALL:
+	case LTM4686_MFR_IOUT_PEAK:
+	case LTM4686_MFR_RETRY_DELAY:
+	case LTM4686_MFR_RESTART_DELAY:
+	case LTM4686_MFR_VOUT_PEAK:
+	case LTM4686_MFR_VIN_PEAK:
+	case LTM4686_MFR_TEMPERATURE_1_PEAK:
+	case LTM4686_MFR_PADS:
+	case LTM4686_MFR_ADDRESS:
+	case LTM4686_MFR_SPECIAL_ID:
+	case LTM4686_MFR_IIN_OFFSET:
+	case LTM4673_MFR_DAC:
+	case LTM4673_MFR_PGD_ASSERTION_DELAY:
+	case LTM4673_MFR_WATCHDOG_T_FIRST:
+	case LTM4673_MFR_WATCHDOG_T:
+	case LTM4673_MFR_IIN_CAL_GAIN:
+		return ltm4686_read_word(ltm4686, ltm4686->page, (uint8_t)reg,
+					 (uint16_t *)readval);
+	case LTM4686_PAGE_PLUS_READ:
+	case LTM4686_SMBALERT_MASK:
+	case LTM4686_MFR_ID:
+	case LTM4686_MFR_MODEL:
+	case LTM4686_MFR_SERIAL:
+		ret = ltm4686_read_block_data(ltm4686, ltm4686->page,
+					      (uint8_t)reg, &block[0], 4);
+		if (ret)
+			return ret;
+
+		*readval = no_os_get_unaligned_be32(block);
+
+		return 0;
+	default:
+		return ltm4686_read_byte(ltm4686, ltm4686->page, (uint8_t)reg,
+					 (uint8_t *)readval);
+	}
+}
+
+/**
+ * @brief Write register value.
+ * @param dev     - The iio device structure.
+ * @param reg	  - Register to write.
+ * @param writeval - Value to write.
+ * @return ret    - Result of the writing procedure.
+*/
+static int32_t ltm4686_iio_reg_write(void *dev, uint32_t reg, uint32_t writeval)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+
+	switch (reg) {
+	case LTM4686_CLEAR_FAULTS:
+	case LTM4686_STORE_USER_ALL:
+	case LTM4686_RESTORE_USER_ALL:
+	case LTM4686_MFR_CLEAR_PEAKS:
+	case LTM4686_MFR_FAULT_LOG_STORE:
+	case LTM4673_MFR_FAULT_LOG_RESTORE:
+	case LTM4686_MFR_FAULT_LOG_CLEAR:
+	case LTM4686_MFR_COMPARE_USER_ALL:
+	case LTM4686_MFR_RESET:
+		return ltm4686_send_byte(dev, ltm4686->page, (uint8_t) reg);
+	case LTM4686_VOUT_COMMAND:
+	case LTM4686_VOUT_MAX:
+	case LTM4686_VOUT_MARGIN_HIGH:
+	case LTM4686_VOUT_MARGIN_LOW:
+	case LTM4686_VOUT_TRANSITION_RATE:
+	case LTM4686_FREQUENCY_SWITCH:
+	case LTM4686_VIN_ON:
+	case LTM4686_VIN_OFF:
+	case LTM4686_VOUT_OV_FAULT_LIMIT:
+	case LTM4686_VOUT_OV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_FAULT_LIMIT:
+	case LTM4686_IOUT_OC_WARN_LIMIT:
+	case LTM4686_OT_FAULT_LIMIT:
+	case LTM4686_OT_WARN_LIMIT:
+	case LTM4686_VIN_UV_WARN_LIMIT:
+	case LTM4686_IIN_OC_WARN_LIMIT:
+	case LTM4686_TON_DELAY:
+	case LTM4686_TON_RISE:
+	case LTM4686_TON_MAX_FAULT_LIMIT:
+	case LTM4686_TOFF_DELAY:
+	case LTM4686_TOFF_FALL:
+	case LTM4686_TOFF_MAX_WARN_LIMIT:
+	case LTM4686_STATUS_WORD:
+	case LTM4686_MFR_USER_DATA_00:
+	case LTM4686_MFR_USER_DATA_01:
+	case LTM4686_MFR_USER_DATA_02:
+	case LTM4686_MFR_USER_DATA_03:
+	case LTM4686_MFR_CHAN_CONFIG:
+	case LTM4686_MFR_CONFIG_ALL:
+	case LTM4686_MFR_PWM_MODE:
+	case LTM4686_MFR_RETRY_DELAY:
+	case LTM4686_MFR_RESTART_DELAY:
+	case LTM4686_MFR_VOUT_PEAK:
+	case LTM4686_MFR_VIN_PEAK:
+	case LTM4686_MFR_TEMPERATURE_1_PEAK:
+	case LTM4686_MFR_ADDRESS:
+		return ltm4686_write_word(ltm4686, ltm4686->page, (uint8_t)reg,
+					  (uint16_t)writeval);
+	default:
+		return ltm4686_write_byte(ltm4686, ltm4686->page, (uint8_t)reg,
+					  (uint8_t)writeval);
+	}
+}
+
+/**
+ * @brief Handles the read request for raw attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_raw(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int ret;
+	uint16_t value;
+
+	switch (channel->address) {
+	case LTM4686_IIO_VIN_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_ALL,
+					LTM4686_READ_VIN, &value);
+		break;
+	case LTM4686_IIO_VOUT_0_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_0,
+					LTM4686_READ_VOUT, &value);
+		break;
+	case LTM4686_IIO_VOUT_1_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_1,
+					LTM4686_READ_VOUT, &value);
+		break;
+	case LTM4686_IIO_VOUT_2_CHAN:
+		if (ltm4686->id != ID_LTM4673)
+			return -ENOTSUP;
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_2,
+					LTM4686_READ_VOUT, &value);
+		break;
+	case LTM4686_IIO_VOUT_3_CHAN:
+		if (ltm4686->id != ID_LTM4673)
+			return -ENOTSUP;
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_3,
+					LTM4686_READ_VOUT, &value);
+		break;
+	case LTM4686_IIO_IIN_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_ALL,
+					LTM4686_READ_IIN, &value);
+		break;
+	case LTM4686_IIO_IOUT_0_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_0,
+					LTM4686_READ_IOUT, &value);
+		break;
+	case LTM4686_IIO_IOUT_1_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_1,
+					LTM4686_READ_IOUT, &value);
+		break;
+	case LTM4686_IIO_IOUT_2_CHAN:
+		if (ltm4686->id != ID_LTM4673)
+			return -ENOTSUP;
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_2,
+					LTM4686_READ_IOUT, &value);
+		break;
+	case LTM4686_IIO_IOUT_3_CHAN:
+		if (ltm4686->id != ID_LTM4673)
+			return -ENOTSUP;
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_3,
+					LTM4686_READ_IOUT, &value);
+		break;
+	case LTM4686_IIO_TEMP_CHAN:
+		ret = ltm4686_read_word(ltm4686, LTM4686_CHAN_ALL,
+					LTM4686_READ_TEMPERATURE_2, &value);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&value);
+}
+
+/**
+ * @brief Handles the read request for scale attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_scale(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	int vals[2], ret;
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+
+	switch (channel->address) {
+	case LTM4686_IIO_VIN_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_ALL,
+					 LTM4686_READ_VIN, &vals[0]);
+		break;
+	case LTM4686_IIO_VOUT_0_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_0,
+					 LTM4686_READ_VOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_VOUT_1_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_1,
+					 LTM4686_READ_VOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_VOUT_2_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_2,
+					 LTM4686_READ_VOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_VOUT_3_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_3,
+					 LTM4686_READ_VOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_IIN_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_ALL,
+					 LTM4686_READ_IIN, &vals[0]);
+		break;
+	case LTM4686_IIO_IOUT_0_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_0,
+					 LTM4686_READ_IOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_IOUT_1_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_1,
+					 LTM4686_READ_IOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_IOUT_2_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_2,
+					 LTM4686_READ_IOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_IOUT_3_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_3,
+					 LTM4686_READ_IOUT, &vals[0]);
+		break;
+	case LTM4686_IIO_TEMP_CHAN:
+		ret = ltm4686_read_value(ltm4686, LTM4686_CHAN_ALL,
+					 LTM4686_READ_TEMPERATURE_2, &vals[0]);
+		break;
+	default:
+		return -EINVAL;
+	}
+	if (ret)
+		return ret;
+
+	vals[1] = (int)MILLI;
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL,
+				2, (int32_t *)vals);
+}
+
+/**
+ * @brief Handles the read request for enable attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_enable(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int ret;
+	uint8_t val;
+
+	ret = ltm4686_read_byte(ltm4686, LTM4686_CHAN_ALL,
+				LTM4686_OPERATION, &val);
+	if (ret)
+		return ret;
+
+	val = (val == LTM4686_OPERATION_OFF) ? 0 : 1;
+
+	return sprintf(buf, "%s ", ltm4686_enable_avail[val]);
+}
+
+/**
+ * @brief Handles the read request for enable_available attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_enable_available(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int length = 0;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(ltm4686_enable_avail); i++)
+		length += sprintf(buf + length, "%s ", ltm4686_enable_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Handles the write request for enable attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_write_enable(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int chan;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(ltm4686_enable_avail); i++)
+		if (!strcmp(buf, ltm4686_enable_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(ltm4686_enable_avail))
+		return -EINVAL;
+
+	chan = no_os_clamp(channel->address, 0U,
+			   (uint32_t)ltm4686->num_channels - 1);
+
+	return ltm4686_set_operation(ltm4686, chan, i ? LTM4686_OPERATION_ON :
+				     LTM4686_OPERATION_OFF);
+}
+
+/**
+ * @brief Handles the read request for vout attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_vout(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int ret, chan, vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltm4686->ltm4686_dev)
+		return -EINVAL;
+
+	chan = no_os_clamp(channel->address, 0U,
+			   (uint32_t)ltm4686->num_channels - 1);
+
+	ret = ltm4686_read_word_data(ltm4686, chan, (uint8_t)priv, &vals[1]);
+	if (ret)
+		return ret;
+
+	vals[0] = (int32_t)(vals[1] / (int)MILLI);
+	vals[1] = (int32_t)((vals[1] * (int)MILLI) % (int)MICRO);
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)vals);
+}
+
+/**
+ * @brief Handles the write request for vout attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_write_vout(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int val1, val2, chan;
+
+	chan = no_os_clamp(channel->address, 0U,
+			   (uint32_t)ltm4686->num_channels - 1);
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, (int32_t *)&val1,
+			(int32_t *)&val2);
+
+	val1 = val1 * (int)MILLI + val2 / (int)MILLI;
+
+	return ltm4686_write_word_data(ltm4686, chan, priv, val1);
+}
+
+/**
+ * @brief Handles the read request for limits global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_limits(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int ret, chan, vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltm4686->ltm4686_dev)
+		return -EINVAL;
+
+	chan = LTM4686_IIO_CHAN(priv);
+	priv = LTM4686_IIO_REG(priv);
+
+	ret = ltm4686_read_word_data(ltm4686, chan, priv, &vals[1]);
+	if (ret)
+		return ret;
+
+	vals[0] = (int32_t)(vals[1] / (int)MILLI);
+	vals[1] = (int32_t)((vals[1] * (int)MILLI) % (int)MICRO);
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)vals);
+}
+
+/**
+ * @brief Handles the write request for limits global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_write_limits(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int val1, val2, chan;
+	bool negative;
+
+	chan = LTM4686_IIO_CHAN(priv);
+	priv = LTM4686_IIO_REG(priv);
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, (int32_t *)&val1,
+			(int32_t *)&val2);
+
+	negative = (val1 < 0 || val2 < 0) ? true : false;
+	if (val1 < 0)
+		val1 = -val1;
+	if (val2 < 0)
+		val2 = -val2;
+
+	val1 = val1 * (int)MILLI + val2 / (int)MILLI;
+
+	if (negative)
+		val1 = -val1;
+
+	return ltm4686_write_word_data(ltm4686, chan, priv, val1);
+}
+
+/**
+ * @brief Handles the read request for status debug attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltm4686_iio_read_status(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct ltm4686_iio_desc *iio_ltm4686 = dev;
+	struct ltm4686_dev *ltm4686 = iio_ltm4686->ltm4686_dev;
+	int ret, chan;
+	int32_t val;
+	uint16_t status_word;
+	uint8_t status_byte;
+
+	chan = LTM4686_IIO_CHAN(priv);
+	priv = LTM4686_IIO_REG(priv);
+
+	if (priv == LTM4686_STATUS_WORD) {
+		ret = ltm4686_read_word(ltm4686, chan, LTM4686_STATUS_WORD,
+					&status_word);
+		if (ret)
+			return ret;
+
+		val = (int32_t)status_word;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	} else {
+		ret = ltm4686_read_byte(ltm4686, chan, (uint8_t)priv,
+					&status_byte);
+		if (ret)
+			return ret;
+
+		val = (int32_t)status_byte;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	}
+}
+
+/**
+ * @brief Initializes the LTM4686 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int ltm4686_iio_init(struct ltm4686_iio_desc **iio_desc,
+		     struct ltm4686_iio_desc_init_param *init_param)
+{
+	struct ltm4686_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->ltm4686_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = ltm4686_init(&descriptor->ltm4686_dev,
+			   init_param->ltm4686_init_param);
+	if (ret)
+		goto dev_err;
+
+	if (descriptor->ltm4686_dev->id == ID_LTM4673)
+		descriptor->iio_dev = &ltm4673_iio_dev;
+	else
+		descriptor->iio_dev = &ltm4686_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+dev_err:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int ltm4686_iio_remove(struct ltm4686_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	no_os_free(iio_desc->iio_dev->channels);
+	ltm4686_remove(iio_desc->ltm4686_dev);
+	no_os_free(iio_desc);
+
+	return 0;
+}
+
+static struct iio_attribute ltm4686_input_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltm4686_iio_read_raw
+	},
+	{
+		.name = "scale",
+		.show = ltm4686_iio_read_scale
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ltm4686_output_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltm4686_iio_read_raw
+	},
+	{
+		.name = "scale",
+		.show = ltm4686_iio_read_scale
+	},
+	{
+		.name = "enable",
+		.show = ltm4686_iio_read_enable,
+		.store = ltm4686_iio_write_enable,
+	},
+	{
+		.name = "enable_available",
+		.show = ltm4686_iio_read_enable_available,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "vout_command",
+		.show = ltm4686_iio_read_vout,
+		.store = ltm4686_iio_write_vout,
+		.priv = LTM4686_VOUT_COMMAND
+	},
+	{
+		.name = "vout_max",
+		.show = ltm4686_iio_read_vout,
+		.store = ltm4686_iio_write_vout,
+		.priv = LTM4686_VOUT_MAX
+	},
+	{
+		.name = "vout_margin_high",
+		.show = ltm4686_iio_read_vout,
+		.store = ltm4686_iio_write_vout,
+		.priv = LTM4686_VOUT_MARGIN_HIGH
+	},
+	{
+		.name = "vout_margin_low",
+		.show = ltm4686_iio_read_vout,
+		.store = ltm4686_iio_write_vout,
+		.priv = LTM4686_VOUT_MARGIN_LOW
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+#define LTM4686_IIO_LIM(_name, _reg, _chan) { \
+	.name = _name, \
+	.show = ltm4686_iio_read_limits, \
+	.store = ltm4686_iio_write_limits, \
+	.priv = LTM4686_IIO_REG_CHAN(_reg, _chan) \
+}
+
+static struct iio_attribute ltm4686_global_attrs[] = {
+	LTM4686_IIO_LIM("vout_ov_fault_limit_0", LTM4686_VOUT_OV_FAULT_LIMIT, 0),
+	LTM4686_IIO_LIM("vout_ov_fault_limit_1", LTM4686_VOUT_OV_FAULT_LIMIT, 1),
+	LTM4686_IIO_LIM("vout_uv_fault_limit_0", LTM4686_VOUT_UV_FAULT_LIMIT, 0),
+	LTM4686_IIO_LIM("vout_uv_fault_limit_1", LTM4686_VOUT_UV_FAULT_LIMIT, 1),
+	LTM4686_IIO_LIM("iout_oc_fault_limit_0", LTM4686_IOUT_OC_FAULT_LIMIT, 0),
+	LTM4686_IIO_LIM("iout_oc_fault_limit_1", LTM4686_IOUT_OC_FAULT_LIMIT, 1),
+	LTM4686_IIO_LIM("ot_fault_limit", LTM4686_OT_FAULT_LIMIT, LTM4686_CHAN_ALL),
+	LTM4686_IIO_LIM("vin_ov_fault_limit", LTM4686_VIN_OV_FAULT_LIMIT, LTM4686_CHAN_ALL),
+	LTM4686_IIO_LIM("vin_uv_warn_limit", LTM4686_VIN_UV_WARN_LIMIT, LTM4686_CHAN_ALL),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ltm4673_global_attrs[] = {
+	LTM4686_IIO_LIM("vout_ov_fault_limit_0", LTM4686_VOUT_OV_FAULT_LIMIT, 0),
+	LTM4686_IIO_LIM("vout_ov_fault_limit_1", LTM4686_VOUT_OV_FAULT_LIMIT, 1),
+	LTM4686_IIO_LIM("vout_ov_fault_limit_2", LTM4686_VOUT_OV_FAULT_LIMIT, 2),
+	LTM4686_IIO_LIM("vout_ov_fault_limit_3", LTM4686_VOUT_OV_FAULT_LIMIT, 3),
+	LTM4686_IIO_LIM("vout_uv_fault_limit_0", LTM4686_VOUT_UV_FAULT_LIMIT, 0),
+	LTM4686_IIO_LIM("vout_uv_fault_limit_1", LTM4686_VOUT_UV_FAULT_LIMIT, 1),
+	LTM4686_IIO_LIM("vout_uv_fault_limit_2", LTM4686_VOUT_UV_FAULT_LIMIT, 2),
+	LTM4686_IIO_LIM("vout_uv_fault_limit_3", LTM4686_VOUT_UV_FAULT_LIMIT, 3),
+	LTM4686_IIO_LIM("iout_oc_fault_limit_0", LTM4686_IOUT_OC_FAULT_LIMIT, 0),
+	LTM4686_IIO_LIM("iout_oc_fault_limit_1", LTM4686_IOUT_OC_FAULT_LIMIT, 1),
+	LTM4686_IIO_LIM("iout_oc_fault_limit_2", LTM4686_IOUT_OC_FAULT_LIMIT, 2),
+	LTM4686_IIO_LIM("iout_oc_fault_limit_3", LTM4686_IOUT_OC_FAULT_LIMIT, 3),
+	LTM4686_IIO_LIM("ot_fault_limit", LTM4686_OT_FAULT_LIMIT, LTM4686_CHAN_ALL),
+	LTM4686_IIO_LIM("vin_ov_fault_limit", LTM4686_VIN_OV_FAULT_LIMIT, LTM4686_CHAN_ALL),
+	LTM4686_IIO_LIM("vin_uv_warn_limit", LTM4686_VIN_UV_WARN_LIMIT, LTM4686_CHAN_ALL),
+	END_ATTRIBUTES_ARRAY
+};
+
+#define LTM4686_IIO_STATUS(_name, _reg, _chan) { \
+	.name = _name, \
+	.show = ltm4686_iio_read_status, \
+	.priv = LTM4686_IIO_REG_CHAN(_reg, _chan) \
+}
+
+static struct iio_attribute ltm4686_debug_attrs[] = {
+	LTM4686_IIO_STATUS("status_vout_0", LTM4686_STATUS_VOUT, 0),
+	LTM4686_IIO_STATUS("status_vout_1", LTM4686_STATUS_VOUT, 1),
+	LTM4686_IIO_STATUS("status_iout_0", LTM4686_STATUS_IOUT, 0),
+	LTM4686_IIO_STATUS("status_iout_1", LTM4686_STATUS_IOUT, 1),
+	LTM4686_IIO_STATUS("status_mfr_specific_0", LTM4686_STATUS_MFR_SPECIFIC, 0),
+	LTM4686_IIO_STATUS("status_mfr_specific_1", LTM4686_STATUS_MFR_SPECIFIC, 1),
+	LTM4686_IIO_STATUS("status_word_0", LTM4686_STATUS_WORD, 0),
+	LTM4686_IIO_STATUS("status_word_1", LTM4686_STATUS_WORD, 1),
+	LTM4686_IIO_STATUS("status_input", LTM4686_STATUS_INPUT, LTM4686_CHAN_ALL),
+	LTM4686_IIO_STATUS("status_temperature", LTM4686_STATUS_TEMPERATURE, LTM4686_CHAN_ALL),
+	LTM4686_IIO_STATUS("status_cml", LTM4686_STATUS_CML, LTM4686_CHAN_ALL),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ltm4673_debug_attrs[] = {
+	LTM4686_IIO_STATUS("status_vout_0", LTM4686_STATUS_VOUT, 0),
+	LTM4686_IIO_STATUS("status_vout_1", LTM4686_STATUS_VOUT, 1),
+	LTM4686_IIO_STATUS("status_vout_2", LTM4686_STATUS_VOUT, 2),
+	LTM4686_IIO_STATUS("status_vout_3", LTM4686_STATUS_VOUT, 3),
+	LTM4686_IIO_STATUS("status_iout_0", LTM4686_STATUS_IOUT, 0),
+	LTM4686_IIO_STATUS("status_iout_1", LTM4686_STATUS_IOUT, 1),
+	LTM4686_IIO_STATUS("status_iout_2", LTM4686_STATUS_IOUT, 2),
+	LTM4686_IIO_STATUS("status_iout_3", LTM4686_STATUS_IOUT, 3),
+	LTM4686_IIO_STATUS("status_mfr_specific_0", LTM4686_STATUS_MFR_SPECIFIC, 0),
+	LTM4686_IIO_STATUS("status_mfr_specific_1", LTM4686_STATUS_MFR_SPECIFIC, 1),
+	LTM4686_IIO_STATUS("status_mfr_specific_2", LTM4686_STATUS_MFR_SPECIFIC, 2),
+	LTM4686_IIO_STATUS("status_mfr_specific_3", LTM4686_STATUS_MFR_SPECIFIC, 3),
+	LTM4686_IIO_STATUS("status_word_0", LTM4686_STATUS_WORD, 0),
+	LTM4686_IIO_STATUS("status_word_1", LTM4686_STATUS_WORD, 1),
+	LTM4686_IIO_STATUS("status_word_2", LTM4686_STATUS_WORD, 2),
+	LTM4686_IIO_STATUS("status_word_3", LTM4686_STATUS_WORD, 3),
+	LTM4686_IIO_STATUS("status_input", LTM4686_STATUS_INPUT, LTM4686_CHAN_ALL),
+	LTM4686_IIO_STATUS("status_temperature", LTM4686_STATUS_TEMPERATURE, LTM4686_CHAN_ALL),
+	LTM4686_IIO_STATUS("status_cml", LTM4686_STATUS_CML, LTM4686_CHAN_ALL),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel ltm4686_channels[] = {
+	{
+		.name = "vin0",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_VIN_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iin0",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_IIN_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iout0",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_IOUT_0_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "iout1",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_1,
+		.address = LTM4686_IIO_IOUT_1_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout0",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_VOUT_0_CHAN,
+		.attributes = ltm4686_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout1",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_1,
+		.address = LTM4686_IIO_VOUT_1_CHAN,
+		.attributes = ltm4686_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "temperature",
+		.ch_type = IIO_TEMP,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_TEMP_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = false,
+	},
+};
+
+static struct iio_channel ltm4673_channels[] = {
+	{
+		.name = "vin0",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_VIN_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iin0",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_IIN_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iout0",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_IOUT_0_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "iout1",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_1,
+		.address = LTM4686_IIO_IOUT_1_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "iout2",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_2,
+		.address = LTM4686_IIO_IOUT_2_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "iout3",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_3,
+		.address = LTM4686_IIO_IOUT_3_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout0",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_VOUT_0_CHAN,
+		.attributes = ltm4686_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout1",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_1,
+		.address = LTM4686_IIO_VOUT_1_CHAN,
+		.attributes = ltm4686_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout2",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_2,
+		.address = LTM4686_IIO_VOUT_2_CHAN,
+		.attributes = ltm4686_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout3",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_3,
+		.address = LTM4686_IIO_VOUT_3_CHAN,
+		.attributes = ltm4686_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "temperature",
+		.ch_type = IIO_TEMP,
+		.indexed = 1,
+		.channel = LTM4686_CHAN_0,
+		.address = LTM4686_IIO_TEMP_CHAN,
+		.attributes = ltm4686_input_attrs,
+		.ch_out = false,
+	},
+};
+
+static struct iio_device ltm4686_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(ltm4686_channels),
+	.channels = ltm4686_channels,
+	.attributes = ltm4686_global_attrs,
+	.debug_attributes = ltm4686_debug_attrs,
+	.debug_reg_read = ltm4686_iio_reg_read,
+	.debug_reg_write = ltm4686_iio_reg_write,
+};
+
+static struct iio_device ltm4673_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(ltm4673_channels),
+	.channels = ltm4673_channels,
+	.attributes = ltm4673_global_attrs,
+	.debug_attributes = ltm4673_debug_attrs,
+	.debug_reg_read = ltm4686_iio_reg_read,
+	.debug_reg_write = ltm4686_iio_reg_write,
+};

--- a/drivers/power/ltm4686/iio_ltm4686.h
+++ b/drivers/power/ltm4686/iio_ltm4686.h
@@ -1,0 +1,62 @@
+/***************************************************************************//**
+ *   @file   iio_ltm4686.h
+ *   @brief  Header file for the LTM4686 IIO Driver
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_LTM4686_H
+#define IIO_LTM4686_H
+
+#include <stdbool.h>
+#include "iio.h"
+#include "ltm4686.h"
+
+/**
+ * @brief Structure holding the LTM4686 IIO device descriptor
+*/
+struct ltm4686_iio_desc {
+	struct ltm4686_dev *ltm4686_dev;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief Structure holding the LTM4686 IIO initialization parameter.
+*/
+struct ltm4686_iio_desc_init_param {
+	struct ltm4686_init_param *ltm4686_init_param;
+};
+
+/** Initializes the LTM4686 IIO descriptor. */
+int ltm4686_iio_init(struct ltm4686_iio_desc **,
+		     struct ltm4686_iio_desc_init_param *);
+
+/** Free resources allocated by the initialization function. */
+int ltm4686_iio_remove(struct ltm4686_iio_desc *);
+
+#endif /* IIO_LTM4686_H */

--- a/drivers/power/ltm4686/ltm4686.c
+++ b/drivers/power/ltm4686/ltm4686.c
@@ -1,0 +1,1251 @@
+/*******************************************************************************
+*   @file   ltm4686.c
+*   @brief  Source code of the LTM4686 Driver
+*   @authors Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2024(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+#include "no_os_crc8.h"
+
+#include "ltm4686.h"
+
+NO_OS_DECLARE_CRC8_TABLE(ltm4686_crc_table);
+
+const struct ltm4686_chip_info ltm4686_info[] = {
+	[ID_LTM4686] = {
+		.num_channels = 2,
+	},
+	[ID_LTM4686B] = {
+		.num_channels = 2,
+	},
+	[ID_LTM4673] = {
+		.num_channels = 4,
+	},
+};
+
+/**
+ * @brief Check if PMBus command is paged
+ *
+ * @param cmd - PMBus command
+ * @return true if paged, false otherwise
+ */
+static bool ltm4686_cmd_is_paged(uint8_t cmd)
+{
+	switch (cmd) {
+	case LTM4686_OPERATION:
+	case LTM4686_ON_OFF_CONFIG:
+	case LTM4686_SMBALERT_MASK:
+	case LTM4686_VOUT_MODE:
+	case LTM4686_VOUT_COMMAND:
+	case LTM4686_VOUT_MAX:
+	case LTM4686_VOUT_MARGIN_HIGH:
+	case LTM4686_VOUT_MARGIN_LOW:
+	case LTM4686_VOUT_TRANSITION_RATE:
+	case LTM4686_IOUT_CAL_GAIN:
+	case LTM4686_VOUT_OV_FAULT_LIMIT:
+	case LTM4686_VOUT_OV_FAULT_RESPONSE:
+	case LTM4686_VOUT_OV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_FAULT_LIMIT:
+	case LTM4686_VOUT_UV_FAULT_RESPONSE:
+	case LTM4686_IOUT_OC_FAULT_RESPONSE:
+	case LTM4686_IOUT_OC_WARN_LIMIT:
+	case LTM4686_OT_FAULT_LIMIT:
+	case LTM4686_OT_FAULT_RESPONSE:
+	case LTM4686_OT_WARN_LIMIT:
+	case LTM4686_UT_FAULT_LIMIT:
+	case LTM4686_UT_FAULT_RESPONSE:
+	case LTM4686_IIN_OC_WARN_LIMIT:
+	case LTM4686_TON_DELAY:
+	case LTM4686_TON_RISE:
+	case LTM4686_TON_MAX_FAULT_LIMIT:
+	case LTM4686_TON_MAX_FAULT_RESPONSE:
+	case LTM4686_TOFF_DELAY:
+	case LTM4686_TOFF_FALL:
+	case LTM4686_TOFF_MAX_WARN_LIMIT:
+	case LTM4686_STATUS_BYTE:
+	case LTM4686_STATUS_WORD:
+	case LTM4686_STATUS_VOUT:
+	case LTM4686_STATUS_IOUT:
+	case LTM4686_STATUS_TEMPERATURE:
+	case LTM4686_STATUS_MFR_SPECIFIC:
+	case LTM4686_READ_VOUT:
+	case LTM4686_READ_IOUT:
+	case LTM4686_READ_TEMPERATURE_1:
+	case LTM4686_READ_DUTY_CYCLE:
+	case LTM4686_READ_POUT:
+	case LTM4686_MFR_VOUT_MAX:
+	case LTM4686_MFR_USER_DATA_01:
+	case LTM4686_MFR_USER_DATA_03:
+	case LTM4686_MFR_CHAN_CONFIG:
+	case LTM4686_MFR_GPIO_PROPAGATE:
+	case LTM4686_MFR_PWM_MODE:
+	case LTM4686_MFR_GPIO_RESPONSE:
+	case LTM4686_MFR_IOUT_PEAK:
+	case LTM4686_MFR_RETRY_DELAY:
+	case LTM4686_MFR_RESTART_DELAY:
+	case LTM4686_MFR_VOUT_PEAK:
+	case LTM4686_MFR_TEMPERATURE_1_PEAK:
+	case LTM4686_MFR_IIN_OFFSET:
+	case LTM4686_MFR_READ_IIN:
+	case LTM4686_MFR_IOUT_CAL_GAIN_TC:
+	case LTM4686_MFR_TEMP_1_GAIN:
+	case LTM4686_MFR_TEMP_1_OFFSET:
+	case LTM4686_MFR_RAIL_ADDRESS:
+		return true;
+	default:
+		return false;
+	}
+}
+
+/**
+ * @brief Converts value to LINEAR16 register data
+ *
+ * @param dev - Device structure
+ * @param data - Value to convert
+ * @param reg - Address of converted register data
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_data2reg_linear16(struct ltm4686_dev *dev, int data,
+				     uint16_t *reg, int scale)
+{
+	if (data <= 0)
+		return -EINVAL;
+	data <<= -(dev->lin16_exp);
+
+	data = NO_OS_DIV_ROUND_CLOSEST_ULL(data, scale);
+	*reg = (uint16_t)no_os_clamp(data, 0, 0xFFFF);
+
+	return 0;
+}
+
+/**
+ * @brief Converts value to LINEAR11 register data
+ *
+ * @param dev - Device structure
+ * @param data - Value to convert
+ * @param reg - Address of converted register data
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_data2reg_linear11(struct ltm4686_dev *dev, int data,
+				     uint16_t *reg, int scale)
+{
+	int exp = 0, mant = 0;
+	uint8_t negative = 0;
+
+	if (data < 0) {
+		negative = 1;
+		data = -data;
+	}
+
+	/* If value too high, continuously do m/2 until m < 1023. */
+	while (data >= LTM4686_LIN11_MANTISSA_MAX * scale &&
+	       exp < LTM4686_LIN11_EXPONENT_MAX) {
+		exp++;
+		data >>= 1;
+	}
+
+	/* If value too low, increase mantissa. */
+	while (data < LTM4686_LIN11_MANTISSA_MIN * scale &&
+	       exp > LTM4686_LIN11_EXPONENT_MIN) {
+		exp--;
+		data <<= 1;
+	}
+
+	mant = no_os_clamp(NO_OS_DIV_ROUND_CLOSEST_ULL(data, scale),
+			   0, 0x3FF);
+	if (negative)
+		mant = -mant;
+
+	*reg = no_os_field_prep(LTM4686_LIN11_MANTISSA_MSK, mant) |
+	       no_os_field_prep(LTM4686_LIN11_EXPONENT_MSK, exp);
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw LINEAR16 register data to its actual value
+ *
+ * @param dev - Device structure
+ * @param reg - LINEAR16 data to convert
+ * @param data - Address of value
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_reg2data_linear16(struct ltm4686_dev *dev, uint16_t reg,
+				     int *data, int scale)
+{
+	int exp = dev->lin16_exp;
+	if (exp < 0)
+		exp = -exp;
+
+	*data = ((int)(reg) * scale) >> exp;
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw LINEAR11 register data to its actual value
+ *
+ * @param dev - Device structure
+ * @param reg - LINEAR11 data to convert
+ * @param data - Address of value
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_reg2data_linear11(struct ltm4686_dev *dev, uint16_t reg,
+				     int *data, int scale)
+{
+	int val, exp, mant;
+
+	exp = LTM4686_LIN11_EXPONENT(reg);
+	mant = LTM4686_LIN11_MANTISSA(reg);
+
+	val = mant * scale;
+	if (exp >= 0)
+		*data = val << exp;
+	else
+		*data = val >> -exp;
+
+	return 0;
+}
+
+/**
+ * @brief Convert value to register data
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Value to convert
+ * @param reg - Address of register data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_data2reg(struct ltm4686_dev *dev, uint8_t cmd,
+			    int data, uint16_t *reg)
+{
+	switch (cmd) {
+	case LTM4686_VOUT_COMMAND:
+	case LTM4686_VOUT_MAX:
+	case LTM4686_VOUT_MARGIN_HIGH:
+	case LTM4686_VOUT_MARGIN_LOW:
+	case LTM4686_VOUT_OV_FAULT_LIMIT:
+	case LTM4686_VOUT_OV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_FAULT_LIMIT:
+	case LTM4686_READ_VOUT:
+	case LTM4686_MFR_VOUT_MAX:
+	case LTM4686_MFR_VOUT_PEAK:
+		return ltm4686_data2reg_linear16(dev, data, reg,
+						 MILLIVOLT_PER_VOLT);
+	case LTM4686_VOUT_TRANSITION_RATE:
+		return ltm4686_data2reg_linear11(dev, data, reg,
+						 MICROVOLT_PER_VOLT);
+	case LTM4686_TON_DELAY:
+	case LTM4686_TON_RISE:
+	case LTM4686_TON_MAX_FAULT_LIMIT:
+	case LTM4686_TOFF_DELAY:
+	case LTM4686_TOFF_FALL:
+	case LTM4686_TOFF_MAX_WARN_LIMIT:
+	case LTM4686_MFR_RETRY_DELAY:
+	case LTM4686_MFR_RESTART_DELAY:
+	case LTM4686_FREQUENCY_SWITCH:
+	case LTM4686_VIN_ON:
+	case LTM4686_VIN_OFF:
+	case LTM4686_IOUT_CAL_GAIN:
+	case LTM4686_IOUT_OC_FAULT_LIMIT:
+	case LTM4686_IOUT_OC_WARN_LIMIT:
+	case LTM4686_OT_FAULT_LIMIT:
+	case LTM4686_OT_WARN_LIMIT:
+	case LTM4686_UT_FAULT_LIMIT:
+	case LTM4686_VIN_OV_FAULT_LIMIT:
+	case LTM4686_VIN_UV_WARN_LIMIT:
+	case LTM4686_IIN_OC_WARN_LIMIT:
+	case LTM4686_READ_VIN:
+	case LTM4686_READ_IIN:
+	case LTM4686_READ_IOUT:
+	case LTM4686_READ_TEMPERATURE_1:
+	case LTM4686_READ_TEMPERATURE_2:
+	case LTM4686_READ_DUTY_CYCLE:
+	case LTM4686_MFR_IOUT_PEAK:
+	case LTM4686_MFR_VIN_PEAK:
+	case LTM4686_MFR_TEMPERATURE_1_PEAK:
+	case LTM4686_MFR_IIN_OFFSET:
+	case LTM4686_MFR_READ_IIN:
+	case LTM4686_MFR_TEMPERATURE_2_PEAK:
+	case LTM4686_MFR_TEMP_1_OFFSET:
+		return ltm4686_data2reg_linear11(dev, data, reg, MILLI);
+	case LTM4686_READ_POUT:
+		return ltm4686_data2reg_linear11(dev, data, reg,
+						 MICROWATT_PER_WATT);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Convert register data to actual value
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param reg - Register data to convert
+ * @param data - Address of converted value
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_reg2data(struct ltm4686_dev *dev, uint8_t cmd,
+			    uint16_t reg, int *data)
+{
+	switch (cmd) {
+	case LTM4686_VOUT_COMMAND:
+	case LTM4686_VOUT_MAX:
+	case LTM4686_VOUT_MARGIN_HIGH:
+	case LTM4686_VOUT_MARGIN_LOW:
+	case LTM4686_VOUT_OV_FAULT_LIMIT:
+	case LTM4686_VOUT_OV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_WARN_LIMIT:
+	case LTM4686_VOUT_UV_FAULT_LIMIT:
+	case LTM4686_READ_VOUT:
+	case LTM4686_MFR_VOUT_MAX:
+	case LTM4686_MFR_VOUT_PEAK:
+		return ltm4686_reg2data_linear16(dev, reg, data,
+						 MILLIVOLT_PER_VOLT);
+	case LTM4686_VOUT_TRANSITION_RATE:
+		return ltm4686_reg2data_linear11(dev, reg, data,
+						 MICROVOLT_PER_VOLT);
+	case LTM4686_TON_DELAY:
+	case LTM4686_TON_RISE:
+	case LTM4686_TON_MAX_FAULT_LIMIT:
+	case LTM4686_TOFF_DELAY:
+	case LTM4686_TOFF_FALL:
+	case LTM4686_TOFF_MAX_WARN_LIMIT:
+	case LTM4686_MFR_RETRY_DELAY:
+	case LTM4686_MFR_RESTART_DELAY:
+	case LTM4686_FREQUENCY_SWITCH:
+	case LTM4686_VIN_ON:
+	case LTM4686_VIN_OFF:
+	case LTM4686_IOUT_CAL_GAIN:
+	case LTM4686_IOUT_OC_FAULT_LIMIT:
+	case LTM4686_IOUT_OC_WARN_LIMIT:
+	case LTM4686_OT_FAULT_LIMIT:
+	case LTM4686_OT_WARN_LIMIT:
+	case LTM4686_UT_FAULT_LIMIT:
+	case LTM4686_VIN_OV_FAULT_LIMIT:
+	case LTM4686_VIN_UV_WARN_LIMIT:
+	case LTM4686_IIN_OC_WARN_LIMIT:
+	case LTM4686_READ_VIN:
+	case LTM4686_READ_IIN:
+	case LTM4686_READ_IOUT:
+	case LTM4686_READ_TEMPERATURE_1:
+	case LTM4686_READ_TEMPERATURE_2:
+	case LTM4686_READ_DUTY_CYCLE:
+	case LTM4686_MFR_IOUT_PEAK:
+	case LTM4686_MFR_VIN_PEAK:
+	case LTM4686_MFR_TEMPERATURE_1_PEAK:
+	case LTM4686_MFR_IIN_OFFSET:
+	case LTM4686_MFR_READ_IIN:
+	case LTM4686_MFR_TEMPERATURE_2_PEAK:
+	case LTM4686_MFR_TEMP_1_OFFSET:
+		return ltm4686_reg2data_linear11(dev, reg, data, MILLI);
+	case LTM4686_READ_POUT:
+		return ltm4686_reg2data_linear11(dev, reg, data,
+						 MICROWATT_PER_WATT);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Perform packet-error checking via CRC
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param buf - Pointer to the first packet buffer
+ * @param nbytes - Packet buffer size
+ * @param op - Operation performed. 0 for write, 1 for read
+ * @return PEC code of the PMBus packet
+ */
+static uint8_t ltm4686_pec(struct ltm4686_dev *dev, uint8_t cmd, uint8_t *buf,
+			   size_t nbytes, uint8_t op)
+{
+	uint8_t crc_buf[nbytes + op + 2];
+
+	crc_buf[0] = (dev->i2c_desc->slave_address << 1);
+	crc_buf[1] = cmd;
+	if (op)
+		crc_buf[2] = (dev->i2c_desc->slave_address << 1) | 1;
+
+	memcpy(&crc_buf[2 + op], buf, nbytes);
+
+	return no_os_crc8(ltm4686_crc_table, crc_buf, nbytes + op + 2, 0);
+}
+
+/**
+ * @brief Match device ID
+ *
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltm4686_match_id(struct ltm4686_dev *dev)
+{
+	int ret;
+	uint16_t word;
+
+	ret = ltm4686_read_word(dev, LTM4686_CHAN_ALL, LTM4686_MFR_SPECIAL_ID,
+				&word);
+	if (ret)
+		return ret;
+
+	switch (dev->id) {
+	case ID_LTM4686:
+	case ID_LTM4686B:
+		if ((word & LTM4686_ID_MSK) != LTM4686_SPECIAL_ID_VALUE)
+			return -EIO;
+		break;
+	case ID_LTM4673:
+		if ((word & LTM4686_ID_MSK) != LTM4673_SPECIAL_ID_VALUE_REV_1)
+			return 0;
+		if ((word & LTM4686_ID_MSK) != LTM4673_SPECIAL_ID_VALUE_REV_2)
+			return 0;
+		break;
+	default:
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the device structure
+ *
+ * @param device - Device structure
+ * @param init_param - Initialization parameters
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_init(struct ltm4686_dev **device,
+		 struct ltm4686_init_param *init_param)
+{
+	struct ltm4686_dev *dev;
+	int ret, i;
+	uint8_t byte;
+
+	dev = (struct ltm4686_dev *)no_os_calloc(1, sizeof(struct ltm4686_dev));
+	if (!dev)
+		return -ENOMEM;
+
+	/* Initialize I2C */
+	ret = no_os_i2c_init(&dev->i2c_desc, init_param->i2c_init);
+	if (ret)
+		goto i2c_err;
+
+	dev->page = LTM4686_CHAN_ALL;
+	dev->id = init_param->id;
+	dev->num_channels = ltm4686_info[dev->id].num_channels;
+	dev->lin16_exp = LTM4686_LIN16_EXPONENT;
+
+	/* Identify device */
+	ret = ltm4686_match_id(dev);
+	if (ret)
+		goto dev_err;
+
+	/* Configure packet error check and syncing enable */
+	ret = ltm4686_read_byte(dev, LTM4686_CHAN_ALL,
+				LTM4686_MFR_CONFIG_ALL, &byte);
+	if (ret)
+		goto dev_err;
+
+	byte &= ~(LTM4686_CONFIG_ALL_PEC_BIT |
+		  LTM4686_CONFIG_ALL_DIS_SYNC_BIT);
+	byte |= no_os_field_prep(LTM4686_CONFIG_ALL_PEC_BIT,
+				 (uint8_t)init_param->crc_en) |
+		no_os_field_prep(LTM4686_CONFIG_ALL_DIS_SYNC_BIT,
+				 (uint8_t)init_param->external_clk_en);
+
+	ret = ltm4686_write_byte(dev, LTM4686_CHAN_ALL,
+				 LTM4686_MFR_CONFIG_ALL, byte);
+	if (ret)
+		goto dev_err;
+
+	dev->crc_en = init_param->crc_en;
+
+	/* Populate CRC table for PEC */
+	if (dev->crc_en)
+		no_os_crc8_populate_msb(ltm4686_crc_table,
+					LTM4686_CRC_POLYNOMIAL);
+
+	/* Initialize GPIO for ALERT */
+	ret = no_os_gpio_get_optional(&dev->alert_desc,
+				      init_param->alert_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_input(dev->alert_desc);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for PGOOD */
+	if (init_param->pgood_params) {
+		for (i = 0; i < dev->num_channels; i++) {
+			ret = no_os_gpio_get_optional(&dev->pgood_descs[i],
+						      init_param->pgood_params[i]);
+			if (ret)
+				goto dev_err;
+
+			ret = no_os_gpio_direction_input(dev->pgood_descs[i]);
+			if (ret)
+				goto dev_err;
+		}
+	}
+
+	/* Initialize GPIO for RUN */
+	if (init_param->run_params) {
+		for (i = 0; i < dev->num_channels; i++) {
+			ret = no_os_gpio_get_optional(&dev->run_descs[i],
+						      init_param->run_params[i]);
+			if (ret)
+				goto dev_err;
+
+			ret = no_os_gpio_direction_output(dev->run_descs[i],
+							  NO_OS_GPIO_HIGH);
+			if (ret)
+				goto dev_err;
+		}
+	}
+
+	/* Initialize GPIO for FAULT */
+	if (init_param->fault_params) {
+		for (i = 0; i < dev->num_channels; i++) {
+			ret = no_os_gpio_get_optional(&dev->fault_descs[i],
+						      init_param->fault_params[i]);
+			if (ret)
+				goto dev_err;
+
+			ret = no_os_gpio_direction_output(dev->fault_descs[i],
+							  NO_OS_GPIO_HIGH);
+			if (ret)
+				goto dev_err;
+		}
+	}
+
+	/* Clear faults */
+	ret = ltm4686_send_byte(dev, LTM4686_CHAN_ALL, LTM4686_CLEAR_FAULTS);
+	if (ret)
+		goto dev_err;
+
+	*device = dev;
+
+	return 0;
+
+dev_err:
+	no_os_i2c_remove(dev->i2c_desc);
+	for (i = 0; i < dev->num_channels; i++) {
+		no_os_gpio_remove(dev->pgood_descs[i]);
+		no_os_gpio_remove(dev->run_descs[i]);
+		no_os_gpio_remove(dev->fault_descs[i]);
+	}
+i2c_err:
+	no_os_free(dev);
+	return ret;
+}
+
+/**
+ * @brief Free or remove device instance
+ *
+ * @param dev - The device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_remove(struct ltm4686_dev *dev)
+{
+	int ret, i;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < dev->num_channels; i++) {
+		no_os_gpio_remove(dev->pgood_descs[i]);
+		no_os_gpio_remove(dev->run_descs[i]);
+		no_os_gpio_remove(dev->fault_descs[i]);
+	}
+
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Set page of the device.
+ * 	  Page 0x0 - Channel 0
+ * 	  Page 0x1 - Channel 1
+ * 	  Page 0x2 - Channel 2
+ * 	  Page 0x3 - Channel 3
+ * 	  Page 0xff - All channels
+ *
+ * @param dev - Device structure
+ * @param page - Page to set
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_set_page(struct ltm4686_dev *dev, int page)
+{
+	int ret = 0;
+	uint8_t read_page;
+	uint8_t tx_buf[3] = {0};
+	uint8_t rx_buf[2] = {0};
+
+
+	if (dev->page != page) {
+		tx_buf[0] = LTM4686_PAGE;
+		tx_buf[1] = page & 0xFF;
+
+		if (dev->crc_en)
+			tx_buf[2] = ltm4686_pec(dev, LTM4686_PAGE,
+						(uint8_t *)&page, 1, 0);
+
+		ret = no_os_i2c_write(dev->i2c_desc, tx_buf,
+				      dev->crc_en + 2, 1);
+		if (ret)
+			return ret;
+
+		ret = no_os_i2c_write(dev->i2c_desc, tx_buf, 1, 0);
+		if (ret)
+			return ret;
+
+		if (dev->crc_en) {
+			ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+			if (ret)
+				return ret;
+
+			if (ltm4686_pec(dev, LTM4686_PAGE, rx_buf, 1, 1) !=
+			    rx_buf[1])
+				return -EBADMSG;
+
+			read_page = rx_buf[0];
+
+		} else {
+			ret = no_os_i2c_read(dev->i2c_desc, &read_page, 1, 1);
+			if (ret)
+				return ret;
+		}
+
+		if (read_page != page)
+			return -EIO;
+
+		dev->page = page;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Send a PMBus command to the device
+ *
+ * @param dev - Device structure
+ * @param page - Page or channel of the command
+ * @param cmd - PMBus command
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_send_byte(struct ltm4686_dev *dev, int page, uint8_t cmd)
+{
+	int ret;
+
+	if (ltm4686_cmd_is_paged(cmd)) {
+		ret = ltm4686_set_page(dev, page);
+		if (ret)
+			return ret;
+	}
+
+	return no_os_i2c_write(dev->i2c_desc, &cmd, 1, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read byte operation
+ *
+ * @param dev - Device structure
+ * @param page - Page or channel of the command
+ * @param cmd - PMBus command
+ * @param data - Address of the byte read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_read_byte(struct ltm4686_dev *dev, int page,
+		      uint8_t cmd, uint8_t *data)
+{
+	int ret;
+	uint8_t rx_buf[2];
+
+	if (ltm4686_cmd_is_paged(cmd)) {
+		ret = ltm4686_set_page(dev, page);
+		if (ret)
+			return ret;
+	}
+
+	ret = no_os_i2c_write(dev->i2c_desc, &cmd, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if (ret)
+			return ret;
+
+		if (ltm4686_pec(dev, cmd, rx_buf, 1, 1) != rx_buf[1])
+			return -EBADMSG;
+
+		*data = rx_buf[0];
+		return ret;
+	} else
+		return no_os_i2c_read(dev->i2c_desc, data, 1, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus write byte operation
+ *
+ * @param dev - Device structure
+ * @param page - Page/channel of the command
+ * @param cmd - PMBus command
+ * @param value - Byte to be written
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_write_byte(struct ltm4686_dev *dev, int page,
+		       uint8_t cmd, uint8_t value)
+{
+	int ret;
+	uint8_t tx_buf[3] = {0};
+
+	if (ltm4686_cmd_is_paged(cmd)) {
+		ret = ltm4686_set_page(dev, page);
+		if (ret)
+			return ret;
+	}
+
+	tx_buf[0] = cmd;
+	tx_buf[1] = value;
+
+	if (dev->crc_en)
+		tx_buf[2] = ltm4686_pec(dev, cmd, &value, 1, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 2, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read word operation
+ *
+ * @param dev - Device structure
+ * @param page - Page/channel of the command
+ * @param cmd - PMBus command
+ * @param word - Address of the read word
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_read_word(struct ltm4686_dev *dev, int page,
+		      uint8_t cmd, uint16_t *word)
+{
+	int ret;
+	uint8_t rx_buf[3] = {0};
+
+	if (ltm4686_cmd_is_paged(cmd)) {
+		ret = ltm4686_set_page(dev, page);
+		if (ret)
+			return ret;
+	}
+
+	ret = no_os_i2c_write(dev->i2c_desc, &cmd, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 3, 1);
+		if (ret)
+			return ret;
+
+		if (ltm4686_pec(dev, cmd, rx_buf, 2, 1) != rx_buf[2])
+			return -EBADMSG;
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if (ret)
+			return ret;
+	}
+
+	*word = no_os_get_unaligned_le16(rx_buf);
+	return 0;
+}
+
+/**
+ * @brief Perform a raw PMBus write word operation
+ *
+ * @param dev - Device structure
+ * @param page - Page/channel of the command
+ * @param cmd - PMBus command
+ * @param word - Word to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_write_word(struct ltm4686_dev *dev, int page,
+		       uint8_t cmd, uint16_t word)
+{
+	int ret;
+	uint8_t tx_buf[4] = {0};
+
+	if (ltm4686_cmd_is_paged(cmd)) {
+		ret = ltm4686_set_page(dev, page);
+		if (ret)
+			return ret;
+	}
+
+	tx_buf[0] = cmd;
+	no_os_put_unaligned_le16(word, &tx_buf[1]);
+
+	if (dev->crc_en)
+		tx_buf[3] = ltm4686_pec(dev, cmd, &tx_buf[1], 2, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 3, 1);
+}
+
+/**
+ * @brief Perform a PMBus read word operation and converts to actual value
+ *
+ * @param dev - Device structure
+ * @param page - Page/channel of the command
+ * @param cmd - PMBus command
+ * @param data - Address of data read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_read_word_data(struct ltm4686_dev *dev, int page,
+			   uint8_t cmd, int *data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = ltm4686_read_word(dev, page, cmd, &reg);
+	if (ret)
+		return ret;
+
+	return ltm4686_reg2data(dev, cmd, reg, data);
+}
+
+/**
+ * @brief Converts value to register data and do PMBus write word operation
+ *
+ * @param dev - Device structure
+ * @param page - Page/channel of the command
+ * @param cmd - PMBus command
+ * @param data - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_write_word_data(struct ltm4686_dev *dev, int page,
+			    uint8_t cmd, int data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = ltm4686_data2reg(dev, cmd, data, &reg);
+	if (ret)
+		return ret;
+
+	return ltm4686_write_word(dev, page, cmd, reg);
+}
+
+/**
+ * @brief Perform a PMBus read block operation
+ *
+ * @param dev - Device structure
+ * @param page - Page/channel of the command
+ * @param cmd - PMBus command
+ * @param data - Address of the read block
+ * @param nbytes - Size of the block in bytes
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_read_block_data(struct ltm4686_dev *dev, int page, uint8_t cmd,
+			    uint8_t *data, size_t nbytes)
+{
+	int ret;
+	uint8_t rxbuf[nbytes + 2];
+
+	ret = ltm4686_set_page(dev, page);
+	if (ret)
+		return ret;
+
+	ret = no_os_i2c_write(dev->i2c_desc, &cmd, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 2, 1);
+		if (ret)
+			return ret;
+
+		if ((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+
+		if (ltm4686_pec(dev, cmd, rxbuf, nbytes + 1, 1) !=
+		    rxbuf[nbytes + 1])
+			return -EBADMSG;
+
+		memcpy(data, &rxbuf[1], nbytes);
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 1, 1);
+		if (ret)
+			return ret;
+
+		if ((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+
+		memcpy(data, &rxbuf[1], nbytes);
+	}
+
+	return 0;
+}
+
+
+/**
+ * @brief Read a value
+ *
+ * @param dev - Device structure
+ * @param channel - Channel selected
+ * @param value_type - Value type.
+ * 		       Example values: LTM4686_VIN
+ * 				       LTM4686_VOUT
+ * 				       LTM4686_IIN
+ * 				       LTM4686_IOUT
+ * 				       LTM4686_TEMP
+ * @param value - Address of the read value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_read_value(struct ltm4686_dev *dev,
+		       uint8_t channel,
+		       enum ltm4686_value_type value_type,
+		       int *value)
+{
+	return ltm4686_read_word_data(dev, channel,
+				      (uint8_t)value_type, value);
+}
+
+/**
+ * @brief Read statuses
+ *
+ * @param dev - Device structure
+ * @param channel - Channel of the status to read
+ * @param status_type - Status type.
+ * 			Example values: LTM4686_STATUS_BYTE_TYPE
+ * 					LTM4686_STATUS_VOUT_TYPE
+ * 					LTM4686_STATUS_IOUT_TYPE
+ * 					LTM4686_STATUS_INPUT_TYPE
+ * 					LTM4686_STATUS_CML_TYPE
+ * @param status - Address of the status structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_read_status(struct ltm4686_dev *dev,
+			uint8_t channel,
+			enum ltm4686_status_type status_type,
+			struct ltm4686_status *status)
+{
+	int ret;
+
+	if (status_type & LTM4686_STATUS_WORD_TYPE) {
+		ret = ltm4686_read_word(dev, channel,
+					LTM4686_STATUS_WORD, &status->word);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_BYTE_TYPE) {
+		ret = ltm4686_read_byte(dev, channel,
+					LTM4686_STATUS_BYTE, &status->byte);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_VOUT_TYPE) {
+		ret = ltm4686_read_byte(dev, channel,
+					LTM4686_STATUS_VOUT, &status->vout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_IOUT_TYPE) {
+		ret = ltm4686_read_byte(dev, channel,
+					LTM4686_STATUS_IOUT, &status->iout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_INPUT_TYPE) {
+		ret = ltm4686_read_byte(dev, LTM4686_CHAN_ALL,
+					LTM4686_STATUS_INPUT, &status->input);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_TEMP_TYPE) {
+		ret = ltm4686_read_byte(dev, channel,
+					LTM4686_STATUS_TEMPERATURE,
+					&status->temp);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_CML_TYPE) {
+		ret = ltm4686_read_byte(dev, LTM4686_CHAN_ALL,
+					LTM4686_STATUS_CML, &status->cml);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTM4686_STATUS_MFR_SPECIFIC_TYPE) {
+		ret = ltm4686_read_byte(dev, channel,
+					LTM4686_STATUS_MFR_SPECIFIC,
+					&status->mfr_specific);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set output voltage and its upper limit
+ *
+ * @param dev - Device structure
+ * @param channel - Channel
+ * @param vout_command - Output voltage in millivolts
+ * @param vout_max - Output voltage upper limit in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_vout_value(struct ltm4686_dev *dev, uint8_t channel,
+		       int vout_command, int vout_max)
+{
+	int ret;
+
+	ret = ltm4686_write_word_data(dev, channel,
+				      LTM4686_VOUT_COMMAND, vout_command);
+	if (ret)
+		return ret;
+
+	return ltm4686_write_word_data(dev, channel,
+				       LTM4686_VOUT_MAX, vout_max);
+}
+
+/**
+ * @brief Set output voltage transition rate
+ *
+ * @param dev - Device structure
+ * @param channel - Channel
+ * @param tr - Transition rate in microV/ms
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_vout_tr(struct ltm4686_dev *dev, uint8_t channel, int tr)
+{
+	return ltm4686_write_word_data(dev, channel,
+				       LTM4686_VOUT_TRANSITION_RATE, tr);
+}
+
+/**
+ * @brief Set output voltage margin
+ *
+ * @param dev - Device structure
+ * @param channel - Channel
+ * @param margin_high - Upper margin in millivolts
+ * @param margin_low - Lower margin in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_vout_margin(struct ltm4686_dev *dev, uint8_t channel,
+			int margin_low, int margin_high)
+{
+	int ret;
+
+	if (margin_high < margin_low)
+		return -EINVAL;
+
+	ret = ltm4686_write_word_data(dev, channel,
+				      LTM4686_VOUT_MARGIN_HIGH, margin_high);
+	if (ret)
+		return ret;
+
+	return ltm4686_write_word_data(dev, channel,
+				       LTM4686_VOUT_MARGIN_LOW, margin_low);
+}
+
+/**
+ * @brief Set input voltage window at which power conversion will proceed
+ *
+ * @param dev - Device structure
+ * @param vin_on - Input voltage in millivolts at which conversion will start
+ * @param vin_off - Input voltage in millivolts at which conversion will stop
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_set_vin(struct ltm4686_dev *dev, int vin_on, int vin_off)
+{
+	int ret;
+
+	if (vin_on < vin_off)
+		return -EINVAL;
+
+	ret = ltm4686_write_word_data(dev, LTM4686_CHAN_ALL,
+				      LTM4686_VIN_ON, vin_on);
+	if (ret)
+		return ret;
+
+	return ltm4686_write_word_data(dev, LTM4686_CHAN_ALL,
+				       LTM4686_VIN_OFF, vin_off);
+}
+
+/**
+ * @brief Set timing values
+ *
+ * @param dev - Device structure
+ * @param channel - Channel
+ * @param timing_type - Timing value type.
+ * 			Example: LTM4686_TON_DELAY_TYPE
+ * 				 LTM4686_TON_RISE_TYPE
+ * 				 LTM4686_TOFF_DELAY_TYPE
+ * 				 LTM4686_RETRY_DELAY_TYPE
+ * @param time - Time value in microseconds
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_set_timing(struct ltm4686_dev *dev, uint8_t channel,
+		       enum ltm4686_timing_type timing_type, int time) // in us
+{
+	return ltm4686_write_word_data(dev, channel, timing_type, time);
+}
+
+/**
+ * @brief Set switching frequency
+ *
+ * @param dev - Device structure
+ * @param freq - Frequency to set.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_switch_freq(struct ltm4686_dev *dev, enum ltm4686_freq freq)
+{
+	int ret;
+
+	if (dev->id == ID_LTM4673)
+		return -ENOTSUP;
+
+	ret = ltm4686_set_operation(dev, LTM4686_CHAN_ALL,
+				    LTM4686_OPERATION_OFF);
+	if (ret)
+		return ret;
+
+	ret = ltm4686_write_word(dev, LTM4686_CHAN_ALL,
+				 LTM4686_FREQUENCY_SWITCH, (uint16_t)freq);
+	if (ret)
+		return ret;
+
+	return ltm4686_set_operation(dev, LTM4686_CHAN_ALL,
+				     LTM4686_OPERATION_ON);
+}
+
+
+/**
+ * @brief Sets the PWM mode for a specific channel of the LTM4686 device.
+ *
+ * @param dev The LTM4686 device structure.
+ * @param channel The channel number.
+ * @param pwm_mode The PWM mode to be set.
+ * @return 0 on success, negative error code on failure.
+ */
+int ltm4686_pwm_mode(struct ltm4686_dev *dev, uint8_t channel,
+		     enum ltm4686_pwm_mode pwm_mode)
+{
+	int ret;
+	uint8_t temp_val;
+
+	if (dev->id == ID_LTM4673)
+		return -ENOTSUP;
+
+	ret = ltm4686_read_byte(dev, channel,
+				LTM4686_MFR_PWM_MODE, &temp_val);
+	if (ret)
+		return ret;
+
+	temp_val &= ~(LTM4686_PWM_OP_MODE_BIT);
+	temp_val |= no_os_field_prep(LTM4686_PWM_OP_MODE_BIT, pwm_mode);
+
+	return ltm4686_write_byte(dev, channel, LTM4686_MFR_PWM_MODE, temp_val);
+}
+
+/**
+ * @brief Set channel operation
+ *
+ * @param dev - Device structure
+ * @param channel - Channel
+ * @param operation - Operation.
+ * 		      Accepted values are: LTM4686_OPERATION_OFF
+ * 					   LTM4686_OPERATION_ON
+ * 					   LTM4686_OPERATION_MARGIN_HIGH
+ * 					   LTM4686_OPERATION_MARGIN_LOW
+ * 					   LTM4686_OPERATION_SEQ_OFF
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_set_operation(struct ltm4686_dev *dev, uint8_t channel,
+			  enum ltm4686_operation_type operation)
+{
+	return ltm4686_write_byte(dev, channel, LTM4686_OPERATION,
+				  (uint8_t)operation);
+}
+
+/**
+ * @brief Perform commands for non-volatile memory/EEPROM
+ *
+ * @param dev - Device structure
+ * @param cmd - NVM commands.
+ * 		Example: LTM4686_STORE_USER
+ * 			 LTM4686_COMPARE_USER
+ * 			 LTM4686_RESTORE_USER
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_nvm_cmd(struct ltm4686_dev *dev, enum ltm4686_nvm_cmd_type cmd)
+{
+	return ltm4686_send_byte(dev, LTM4686_CHAN_ALL, (uint8_t)cmd);
+}
+
+/**
+ * @brief Perform a device software reset
+ *
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltm4686_software_reset(struct ltm4686_dev *dev)
+{
+	return ltm4686_send_byte(dev, LTM4686_CHAN_ALL, LTM4686_MFR_RESET);
+}

--- a/drivers/power/ltm4686/ltm4686.h
+++ b/drivers/power/ltm4686/ltm4686.h
@@ -1,0 +1,459 @@
+/*******************************************************************************
+*   @file   ltm4686.h
+*   @brief  Header file of the LTM4686 Driver
+*   @authors Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2024(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __LTM4686_H__
+#define __LTM4686_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* PMBus commands */
+#define LTM4686_PAGE				0x00
+#define LTM4686_OPERATION			0x01
+#define LTM4686_ON_OFF_CONFIG			0x02
+#define LTM4686_CLEAR_FAULTS			0x03
+#define LTM4686_PAGE_PLUS_WRITE			0x05
+#define LTM4686_PAGE_PLUS_READ			0x06
+
+#define LTM4686_WRITE_PROTECT			0x10
+#define LTM4686_STORE_USER_ALL			0x15
+#define LTM4686_RESTORE_USER_ALL		0x16
+
+#define LTM4686_CAPABILITY			0x19
+#define LTM4686_SMBALERT_MASK			0x1B
+
+#define LTM4686_VOUT_MODE			0x20
+#define LTM4686_VOUT_COMMAND			0x21
+#define LTM4686_VOUT_MAX			0x24
+#define LTM4686_VOUT_MARGIN_HIGH		0x25
+#define LTM4686_VOUT_MARGIN_LOW			0x26
+#define LTM4686_VOUT_TRANSITION_RATE		0x27
+
+#define LTM4686_FREQUENCY_SWITCH		0x33
+#define LTM4686_VIN_ON				0x35
+#define LTM4686_VIN_OFF				0x36
+#define LTM4686_IOUT_CAL_GAIN			0x38
+
+#define LTM4686_VOUT_OV_FAULT_LIMIT		0x40
+#define LTM4686_VOUT_OV_FAULT_RESPONSE		0x41
+#define LTM4686_VOUT_OV_WARN_LIMIT		0x42
+#define LTM4686_VOUT_UV_WARN_LIMIT		0x43
+#define LTM4686_VOUT_UV_FAULT_LIMIT		0x44
+#define LTM4686_VOUT_UV_FAULT_RESPONSE		0x45
+#define LTM4686_IOUT_OC_FAULT_LIMIT		0x46
+#define LTM4686_IOUT_OC_FAULT_RESPONSE		0x47
+#define LTM4686_IOUT_OC_WARN_LIMIT		0x4A
+
+#define LTM4686_OT_FAULT_LIMIT			0x4F
+#define LTM4686_OT_FAULT_RESPONSE		0x50
+#define LTM4686_OT_WARN_LIMIT			0x51
+#define LTM4686_UT_FAULT_LIMIT			0x53
+#define LTM4686_UT_FAULT_RESPONSE		0x54
+
+#define LTM4686_VIN_OV_FAULT_LIMIT		0x55
+#define LTM4686_VIN_OV_FAULT_RESPONSE		0x56
+#define LTM4686_VIN_UV_WARN_LIMIT		0x58
+#define LTM4686_IIN_OC_WARN_LIMIT		0x5D
+
+#define LTM4686_TON_DELAY			0x60
+#define LTM4686_TON_RISE			0x61
+#define LTM4686_TON_MAX_FAULT_LIMIT		0x62
+#define LTM4686_TON_MAX_FAULT_RESPONSE		0x63
+#define LTM4686_TOFF_DELAY			0x64
+#define LTM4686_TOFF_FALL			0x65
+#define LTM4686_TOFF_MAX_WARN_LIMIT		0x66
+
+#define LTM4686_STATUS_BYTE			0x78
+#define LTM4686_STATUS_WORD			0x79
+#define LTM4686_STATUS_VOUT			0x7A
+#define LTM4686_STATUS_IOUT			0x7B
+#define LTM4686_STATUS_INPUT			0x7C
+#define LTM4686_STATUS_TEMPERATURE		0x7D
+#define LTM4686_STATUS_CML			0x7E
+#define LTM4686_STATUS_MFR_SPECIFIC		0x80
+
+#define LTM4686_READ_VIN			0x88
+#define LTM4686_READ_IIN			0x89
+#define LTM4686_READ_VOUT			0x8B
+#define LTM4686_READ_IOUT			0x8C
+#define LTM4686_READ_TEMPERATURE_1		0x8D
+#define LTM4686_READ_TEMPERATURE_2		0x8E
+#define LTM4686_READ_DUTY_CYCLE			0x94
+#define LTM4686_READ_POUT			0x96
+
+#define LTM4686_REVISION			0x98
+#define LTM4686_MFR_ID				0x99
+#define LTM4686_MFR_MODEL			0x9A
+#define LTM4686_MFR_SERIAL			0x9E
+#define LTM4686_MFR_VOUT_MAX			0xA5
+
+#define LTM4686_MFR_USER_DATA_00		0xB0
+#define LTM4686_MFR_USER_DATA_01		0xB1
+#define LTM4686_MFR_USER_DATA_02		0xB2
+#define LTM4686_MFR_USER_DATA_03		0xB3
+#define LTM4686_MFR_USER_DATA_04		0xB4
+
+#define LTM4686_MFR_INFO			0xB6
+#define LTM4686_MFR_EE_UNLOCK			0xBD
+#define LTM4686_MFR_EE_ERASE			0xBE
+#define LTM4686_MFR_EE_DATA			0xBF
+
+#define LTM4686_MFR_CHAN_CONFIG			0xD0
+#define LTM4686_MFR_CONFIG_ALL			0xD1
+#define LTM4686_MFR_GPIO_PROPAGATE		0xD2
+#define LTM4686_MFR_PWM_MODE			0xD4
+#define LTM4686_MFR_GPIO_RESPONSE		0xD5
+#define LTM4686_MFR_OT_FAULT_RESPONSE		0xD6
+#define LTM4686_MFR_IOUT_PEAK			0xD7
+#define LTM4686_MFR_ADC_CONTROL			0xD8
+#define LTM4686_MFR_ADC_TELEMETRY_STATUS	0xDA
+#define LTM4686_MFR_RETRY_DELAY			0xDB
+#define LTM4686_MFR_RESTART_DELAY		0xDC
+#define LTM4686_MFR_VOUT_PEAK			0xDD
+#define LTM4686_MFR_VIN_PEAK			0xDE
+#define LTM4686_MFR_TEMPERATURE_1_PEAK		0xDF
+#define LTM4686_MFR_CLEAR_PEAKS			0xE3
+#define LTM4686_MFR_PADS			0xE5
+#define LTM4686_MFR_ADDRESS			0xE6
+#define LTM4686_MFR_SPECIAL_ID			0xE7
+#define LTM4686_MFR_IIN_OFFSET			0xE9
+#define LTM4686_MFR_FAULT_LOG_STORE		0xEA
+#define LTM4686_MFR_FAULT_LOG_CLEAR		0xEC
+#define LTM4686_MFR_READ_IIN			0xED
+#define LTM4686_MFR_FAULT_LOG			0xEE
+#define LTM4686_MFR_COMMON			0xEF
+#define LTM4686_MFR_COMPARE_USER_ALL		0xF0
+#define LTM4686_MFR_TEMPERATURE_2_PEAK		0xF4
+#define LTM4686_MFR_PWM_CONFIG			0xF5
+#define LTM4686_MFR_IOUT_CAL_GAIN_TC		0xF6
+#define LTM4686_MFR_TEMP_1_GAIN			0xF8
+#define LTM4686_MFR_TEMP_1_OFFSET		0xF9
+#define LTM4686_MFR_RAIL_ADDRESS		0xFA
+#define LTM4686_MFR_RESET			0xFD
+
+/* LTM4673 manufacturer-specific commands */
+#define LTM4673_MFR_FAULTB0_PROPAGATE		0xD2
+#define LTM4673_MFR_FAULTB1_PROPAGATE		0xD3
+#define LTM4673_MFR_PWRGD_ENABLE		0xD4
+#define LTM4673_MFR_FAULTB0_RESPONSE		0xD5
+#define LTM4673_MFR_FAULTB1_RESPONSE		0xD6
+#define LTM4673_MFR_IOUT_MIN			0xD8
+#define LTM4673_MFR_CONFIG2			0xD9
+#define LTM4673_MFR_CONFIG3			0xDA
+#define LTM4673_MFR_DAC				0xE0
+#define LTM4673_MFR_PGD_ASSERTION_DELAY		0xE1
+#define LTM4673_MFR_WATCHDOG_T_FIRST		0xE2
+#define LTM4673_MFR_WATCHDOG_T			0xE3
+#define LTM4673_MFR_PAGE_FF_MASK		0xE4
+#define LTM4673_MFR_IIN_CAL_GAIN		0xE8
+#define LTM4673_MFR_VOUT_DISCHARGE_THRESHOLD	0xE9
+#define LTM4673_MFR_FAULT_LOG_RESTORE		0xEB
+#define LTM4673_MFR_FAULT_LOG_STATUS		0xED
+#define LTM4673_MFR_RETRY_COUNT			0xF7
+#define LTM4673_MFR_IOUT_SENSE_VOLTAGE		0xFA
+#define LTM4673_MFR_VOUT_MIN			0xFB
+#define LTM4673_MFR_VIN_MIN			0xFC
+#define LTM4673_MFR_TEMPERATURE_1_MIN		0xFD
+
+/* PMBus-specific parameters */
+#define LTM4686_CRC_POLYNOMIAL			0x7
+#define LTM4686_VOUT_MODE_VAL_MSK		NO_OS_GENMASK(4,0)
+
+/* LINEAR data format params */
+#define LTM4686_LIN11_MANTISSA_MAX		1023L
+#define LTM4686_LIN11_MANTISSA_MIN		511L
+#define LTM4686_LIN11_EXPONENT_MAX		15
+#define LTM4686_LIN11_EXPONENT_MIN		-15
+#define LTM4686_LIN11_MANTISSA_MSK		NO_OS_GENMASK(10,0)
+#define LTM4686_LIN11_EXPONENT_MSK		NO_OS_GENMASK(15,11)
+#define LTM4686_LIN11_EXPONENT(x)		((int16_t)(x) >> 11)
+#define LTM4686_LIN11_MANTISSA(x)		(((int16_t)((x & 0x7FF) << 5)) >> 5)
+#define LTM4686_LIN16_EXPONENT			-12
+
+/* LTM4686 channel numbers */
+#define LTM4686_CHAN_0				0x0
+#define LTM4686_CHAN_1				0x1
+#define LTM4686_CHAN_2				0x2
+#define LTM4686_CHAN_3				0x3
+#define LTM4686_CHAN_ALL			0xFF
+
+/* Status types masks */
+#define LTM4686_STATUS_BYTE_TYPE_MSK		0x01
+#define LTM4686_STATUS_VOUT_TYPE_MSK		0x02
+#define LTM4686_STATUS_IOUT_TYPE_MSK		0x04
+#define LTM4686_STATUS_INPUT_TYPE_MSK		0x08
+#define LTM4686_STATUS_TEMP_TYPE_MSK		0x10
+#define LTM4686_STATUS_CML_TYPE_MSK		0x20
+#define LTM4686_STATUS_MFR_SPECIFIC_TYPE_MSK	0x40
+#define LTM4686_STATUS_WORD_TYPE_MSK		0x80
+#define LTM4686_STATUS_ALL_TYPE_MSK		0xFF
+
+/* LTM4686 configurable bits and masks */
+#define LTM4686_PWM_OP_MODE_BIT			NO_OS_BIT(0)
+#define LTM4686_CONFIG_ALL_DIS_SYNC_BIT		NO_OS_BIT(4)
+#define LTM4686_CONFIG_ALL_PEC_BIT		NO_OS_BIT(2)
+
+/* LTM4686 ID values */
+#define LTM4686_ID_MSK				0xFFF0
+#define LTM4686_SPECIAL_ID_VALUE		0x4770
+#define LTM4673_SPECIAL_ID_VALUE_REV_1		0x0230
+#define LTM4673_SPECIAL_ID_VALUE_REV_2		0x4480
+
+enum ltm4686_chip_id {
+	ID_LTM4686,
+	ID_LTM4686B,
+	ID_LTM4673,
+};
+
+enum ltm4686_fault_pin_config {
+	LTM4686_FAULT_PIN_INPUT,
+	LTM4686_FAULT_PIN_OUTPUT,
+};
+
+enum ltm4686_operation_type {
+	LTM4686_OPERATION_OFF = 0x00,
+	LTM4686_OPERATION_ON = 0x80,
+	LTM4686_OPERATION_MARGIN_LOW = 0x98,
+	LTM4686_OPERATION_MARGIN_HIGH = 0xA8,
+	LTM4686_OPERATION_SEQ_OFF = 0x40,
+};
+
+enum ltm4686_value_type {
+	LTM4686_VIN = LTM4686_READ_VIN,
+	LTM4686_IIN = LTM4686_READ_IIN,
+	LTM4686_VOUT = LTM4686_READ_VOUT,
+	LTM4686_IOUT = LTM4686_READ_IOUT,
+	LTM4686_TEMP_TSNS = LTM4686_READ_TEMPERATURE_1,
+	LTM4686_TEMP_IC = LTM4686_READ_TEMPERATURE_2,
+	LTM4686_DUTY_CYCLE = LTM4686_READ_DUTY_CYCLE,
+	LTM4686_POUT = LTM4686_READ_POUT,
+	LTM4686_IOUT_PEAK = LTM4686_MFR_IOUT_PEAK,
+	LTM4686_VOUT_PEAK = LTM4686_MFR_VOUT_PEAK,
+	LTM4686_VIN_PEAK = LTM4686_MFR_VIN_PEAK,
+	LTM4686_TEMP_PEAK = LTM4686_MFR_TEMPERATURE_1_PEAK,
+};
+
+enum ltm4686_status_type {
+	LTM4686_STATUS_ALL_TYPE = LTM4686_STATUS_ALL_TYPE_MSK,
+	LTM4686_STATUS_BYTE_TYPE = LTM4686_STATUS_BYTE_TYPE_MSK,
+	LTM4686_STATUS_VOUT_TYPE = LTM4686_STATUS_VOUT_TYPE_MSK,
+	LTM4686_STATUS_IOUT_TYPE = LTM4686_STATUS_IOUT_TYPE_MSK,
+	LTM4686_STATUS_INPUT_TYPE = LTM4686_STATUS_INPUT_TYPE_MSK,
+	LTM4686_STATUS_TEMP_TYPE = LTM4686_STATUS_TEMP_TYPE_MSK,
+	LTM4686_STATUS_CML_TYPE = LTM4686_STATUS_CML_TYPE_MSK,
+	LTM4686_STATUS_MFR_SPECIFIC_TYPE = LTM4686_STATUS_MFR_SPECIFIC_TYPE_MSK,
+	LTM4686_STATUS_WORD_TYPE = LTM4686_STATUS_WORD_TYPE_MSK,
+};
+
+enum ltm4686_timing_type {
+	LTM4686_TON_DELAY_TYPE = LTM4686_TON_DELAY,
+	LTM4686_TON_RISE_TYPE = LTM4686_TON_RISE,
+	LTM4686_TOFF_DELAY_TYPE = LTM4686_TOFF_DELAY,
+	LTM4686_TOFF_FALL_TYPE = LTM4686_TOFF_FALL,
+	LT7182_RETRY_DELAY = LTM4686_MFR_RETRY_DELAY,
+	LTM4686_RESTART_DELAY = LTM4686_MFR_RESTART_DELAY,
+};
+
+enum ltm4686_freq {
+	LTM4686_FREQ_EXT_OSC,
+	LTM4686_FREQ_250_KHZ = 0xF3E8,
+	LTM4686_FREQ_350_KHZ = 0xFABC,
+	LTM4686_FREQ_425_KHZ = 0xFB52,
+	LTM4686_FREQ_500_KHZ = 0xFBE8,
+	LTM4686_FREQ_575_KHZ = 0x023F,
+	LTM4686_FREQ_650_KHZ = 0x028A,
+	LTM4686_FREQ_750_KHZ = 0x02EE,
+	LTM4686_FREQ_1000_KHZ = 0x03E8,
+};
+
+enum ltm4686_nvm_cmd_type {
+	LTM4686_STORE_USER = LTM4686_STORE_USER_ALL,
+	LTM4686_RESTORE_USER = LTM4686_RESTORE_USER_ALL,
+	LTM4686_COMPARE_USER = LTM4686_MFR_COMPARE_USER_ALL,
+};
+
+enum ltm4686_pwm_mode {
+	LTM4686_PWM_FORCED_CONTINUOUS_MODE,
+	LTM4686_PWM_PULSE_SKIP_MODE,
+};
+
+struct ltm4686_dev {
+	struct no_os_i2c_desc *i2c_desc;
+	struct no_os_gpio_desc *alert_desc;
+	struct no_os_gpio_desc **pgood_descs;
+	struct no_os_gpio_desc **run_descs;
+	struct no_os_gpio_desc **fault_descs;
+
+	enum ltm4686_chip_id id;
+	int page;
+	int lin16_exp;
+	bool crc_en;
+	uint8_t num_channels;
+};
+
+struct ltm4686_init_param {
+	struct no_os_i2c_init_param *i2c_init;
+	struct no_os_gpio_init_param *alert_param;
+	struct no_os_gpio_init_param **pgood_params;
+	struct no_os_gpio_init_param **run_params;
+	struct no_os_gpio_init_param **fault_params;
+
+	enum ltm4686_chip_id id;
+	bool external_clk_en;
+	bool crc_en;
+};
+
+struct ltm4686_chip_info {
+	uint8_t num_channels;
+};
+
+struct ltm4686_status {
+	uint16_t word;
+	uint8_t byte;
+	uint8_t vout;
+	uint8_t iout;
+	uint8_t input;
+	uint8_t temp;
+	uint8_t cml;
+	uint8_t mfr_specific;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the device structure */
+int ltm4686_init(struct ltm4686_dev **device,
+		 struct ltm4686_init_param *init_param);
+
+/* Free or remove device instance */
+int ltm4686_remove(struct ltm4686_dev *dev);
+
+/* Set PMBus page and phase */
+int ltm4686_set_page(struct ltm4686_dev *dev, int page);
+
+/* Send a PMBus command to the device */
+int ltm4686_send_byte(struct ltm4686_dev *dev, int page, uint8_t cmd);
+
+/* Perform a PMBus read_byte operation */
+int ltm4686_read_byte(struct ltm4686_dev *dev, int page,
+		      uint8_t cmd, uint8_t *data);
+
+/*  Perform a PMBus write_byte operation */
+int ltm4686_write_byte(struct ltm4686_dev *dev, int page,
+		       uint8_t cmd, uint8_t value);
+
+/* Perform a PMBus read_word operation */
+int ltm4686_read_word(struct ltm4686_dev *dev, int page,
+		      uint8_t cmd, uint16_t *word);
+
+/* Perform a PMBus write_word operation */
+int ltm4686_write_word(struct ltm4686_dev *dev, int page,
+		       uint8_t cmd, uint16_t word);
+
+/* Perform a PMBus read_word operation then perform conversion*/
+int ltm4686_read_word_data(struct ltm4686_dev *dev, int page,
+			   uint8_t cmd, int *data);
+
+/* Perform conversion then perform a PMBus write_word operation */
+int ltm4686_write_word_data(struct ltm4686_dev *dev, int page,
+			    uint8_t cmd, int data);
+
+/* Read a block of bytes */
+int ltm4686_read_block_data(struct ltm4686_dev *dev, int page, uint8_t cmd,
+			    uint8_t *data, size_t nbytes);
+
+/* Read specific value type */
+int ltm4686_read_value(struct ltm4686_dev *dev,
+		       uint8_t channel,
+		       enum ltm4686_value_type value_type,
+		       int *value);
+
+/* Read status */
+int ltm4686_read_status(struct ltm4686_dev *dev,
+			uint8_t channel,
+			enum ltm4686_status_type status_type,
+			struct ltm4686_status *status);
+
+/* Set VOUT parameters: VOUT_COMMAND and VOUT_MAX */
+int ltm4686_vout_value(struct ltm4686_dev *dev, uint8_t channel,
+		       int vout_command, int vout_max);
+
+/* Set VOUT transition rate in microvolt per milliseconds */
+int ltm4686_vout_tr(struct ltm4686_dev *dev, uint8_t channel, int tr);
+
+/* Set VOUT margins */
+int ltm4686_vout_margin(struct ltm4686_dev *dev, uint8_t channel,
+			int margin_low, int margin_high);
+
+/* Set VIN threshold when to start power conversion */
+int ltm4686_set_vin(struct ltm4686_dev *dev, int vin_on, int vin_off);
+
+/* Set timing values in microseconds */
+int ltm4686_set_timing(struct ltm4686_dev *dev, uint8_t channel,
+		       enum ltm4686_timing_type timing_type, int time);
+
+/* Set switching frequency */
+int ltm4686_switch_freq(struct ltm4686_dev *dev, enum ltm4686_freq freq);
+
+/* Set PWM mode of a channel */
+int ltm4686_pwm_mode(struct ltm4686_dev *dev, uint8_t channel,
+		     enum ltm4686_pwm_mode pwm_mode);
+
+/* Set operation */
+int ltm4686_set_operation(struct ltm4686_dev *dev, uint8_t channel,
+			  enum ltm4686_operation_type operation);
+
+/* NVM/EEPROM user commands */
+int ltm4686_nvm_cmd(struct ltm4686_dev *dev, enum ltm4686_nvm_cmd_type cmd);
+
+/* Software reset */
+int ltm4686_software_reset(struct ltm4686_dev *dev);
+
+#endif /* __LTM4686_H__ */

--- a/projects/ltm4686/Makefile
+++ b/projects/ltm4686/Makefile
@@ -1,0 +1,9 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = n
+IIO_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ltm4686/README.rst
+++ b/projects/ltm4686/README.rst
@@ -1,0 +1,191 @@
+Evaluating the LTM4686
+======================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `DC2722A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc2722a.html>`_
+* `DC3089A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc3089a.html>`_
+* `DC2810A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc2810a.html>`_
+
+Overview
+--------
+
+The DC2722A/DC3089A are dual-output, high efficiency, high density, µModule
+regulator with 2.7V to 17V/5.75V input range. Each output can supply 10A/14A
+maximum load current. Meanwhile, the DC2810A is a wide input and output voltage
+range, high efficiency and  power density, quad output DC/DC step-down 
+µModule regulator with default input range of 4.5V to 15V.
+
+Full performance details are provided in the corresponding data sheet for
+LTM4686, LTM4686B and LTM4673, which should be consulted in conjunction with
+user guide.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This specific project makes use of the DC2722A powered up by a 12V power supply.
+
+**Pin Description**
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	|  1  | VDD25	 | 2.5V Power supply output		     |
+	+-----+----------+-------------------------------------------+
+	|  2  | SGND	 | Signal ground			     |
+	+-----+----------+-------------------------------------------+
+	|  3  | RUN1	 | Enable pin for Channel 1		     |
+	+-----+----------+-------------------------------------------+
+	|  4  | GPIO1	 | General Purpose Input Output		     |
+	+-----+----------+-------------------------------------------+
+	|  5  | SDA	 | I2C Serial Data Line			     |
+	+-----+----------+-------------------------------------------+
+	|  6  | SCL	 | I2C Serial Clock Line		     |
+	+-----+----------+-------------------------------------------+
+	|  7  | ALERT	 | Alert output pins			     |
+	+-----+----------+-------------------------------------------+
+	|  8  | SGND	 | Signal ground			     |
+	+-----+----------+-------------------------------------------+
+	|  9  | AUXP	 | Auxiliary I2C input supply		     |
+	+-----+----------+-------------------------------------------+
+	| 10  | GND1_SNS | Sense Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 11  | VO1_SNS	 | Channel 1 sense voltage		     |
+	+-----+----------+-------------------------------------------+
+	| 12  | VO0_SNS	 | Channel 0 sense voltage		     |
+	+-----+----------+-------------------------------------------+
+	| 13  | GND0_SNS | Sense Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 14  | IOSTEP_CLK| IOSTEP clock			     |
+	+-----+----------+-------------------------------------------+
+	| 15  | GND	 | Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 16  | VDD33	 | 3.3V Power supply output		     |
+	+-----+----------+-------------------------------------------+
+	| 17  | RUN0	 | Enable pin for Channel 0		     |
+	+-----+----------+-------------------------------------------+
+	| 18  | GPIO0	 | General Purpose Input Output		     |
+	+-----+----------+-------------------------------------------+
+	| 19  | SYNC	 | Clock synchronization input		     |
+	+-----+----------+-------------------------------------------+
+	| 20  | INTVCC	 | Internal regulator 5V output		     |
+	+-----+----------+-------------------------------------------+
+	| 21  | SHARE_CLK| Bidirectional clock sharing pin	     |
+	+-----+----------+-------------------------------------------+
+	| 22  | GND	 | Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 23  | VIN	 | Voltage input			     |
+	+-----+----------+-------------------------------------------+
+	| 24  | GND	 | Ground				     |
+	+-----+----------+-------------------------------------------+
+
+**Hardware Bringup**
+
+For reference, follow the Quick Start Procedure section of the corresponding
+demo board.
+`user guide <https://www.analog.com/media/en/technical-documentation/user-guides/DC2722A_UG-1397.pdf>`_.
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltm4686/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltm4686/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the ltm4686, and performs telemetry
+readings of the voltage, current and temperature of each output channel. Status
+bytes/words are also monitored in the example.
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltm4686/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for DC3190A-A evaluation board.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO ltm4686 driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltm4686/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltm4686/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `DC2722A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc2722a.html>`_
+* `MAX32666FTHR <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666fthr.html>`_
+
+**Connections**:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| DC2722A Pin Number	      |  Mnemonic  | Function					  | MAX32666FTHR Pin Number	|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 5			      | SDA	   | I2C Serial Data				  | I2C0_SCL		        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 6			      | SCL	   | I2C Serial Clock				  | I2C0_SDA		        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 11			      | VO1_SNS	   | Connect to load				  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 12			      | VO0_SNS	   | Connect to load				  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 15			      | GND	   | Ground					  | GND				|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 23			      | VIN	   | Connect to external power supply (12V)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32665
+	# to flash the code
+	make run

--- a/projects/ltm4686/builds.json
+++ b/projects/ltm4686/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_example_max32666": {
+			"flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n TARGET=max32665"
+		},
+		"iio_example_max32666": {
+			"flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32665"
+		}
+	}
+}

--- a/projects/ltm4686/src.mk
+++ b/projects/ltm4686/src.mk
@@ -1,0 +1,46 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+	
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     		\
+		$(INCLUDE)/no_os_error.h     	\
+		$(INCLUDE)/no_os_list.h     	\
+		$(INCLUDE)/no_os_gpio.h      	\
+		$(INCLUDE)/no_os_dma.h      	\
+		$(INCLUDE)/no_os_print_log.h 	\
+		$(INCLUDE)/no_os_i2c.h       	\
+		$(INCLUDE)/no_os_irq.h		\
+		$(INCLUDE)/no_os_pwm.h       	\
+		$(INCLUDE)/no_os_rtc.h       	\
+		$(INCLUDE)/no_os_uart.h      	\
+		$(INCLUDE)/no_os_lf256fifo.h 	\
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h        \
+		$(INCLUDE)/no_os_alloc.h        \
+                $(INCLUDE)/no_os_mutex.h	\
+		$(INCLUDE)/no_os_crc8.h	
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
+		$(DRIVERS)/api/no_os_i2c.c  	\
+		$(DRIVERS)/api/no_os_dma.c  	\
+		$(DRIVERS)/api/no_os_uart.c  	\
+		$(DRIVERS)/api/no_os_irq.c  	\
+		$(DRIVERS)/api/no_os_gpio.c  	\
+		$(DRIVERS)/api/no_os_pwm.c	\
+		$(NO-OS)/util/no_os_util.c	\
+		$(NO-OS)/util/no_os_list.c      \
+		$(NO-OS)/util/no_os_alloc.c 	\
+		$(NO-OS)/util/no_os_mutex.c	\
+		$(NO-OS)/util/no_os_crc8.c
+
+INCS += $(DRIVERS)/power/ltm4686/ltm4686.h
+SRCS += $(DRIVERS)/power/ltm4686/ltm4686.c

--- a/projects/ltm4686/src/common/common_data.c
+++ b/projects/ltm4686/src/common/common_data.c
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ltm4686 examples.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param ltm4686_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_i2c_init_param ltm4686_i2c_ip = {
+	.device_id = 1,
+	.max_speed_hz = 100000,
+	.platform_ops = I2C_OPS,
+	.slave_address = LTM4686_ADDRESS,
+	.extra = I2C_EXTRA,
+};
+
+struct ltm4686_init_param ltm4686_ip = {
+	.i2c_init = &ltm4686_i2c_ip,
+	.crc_en = true,
+	.id = ID_LTM4686,
+};

--- a/projects/ltm4686/src/common/common_data.h
+++ b/projects/ltm4686/src/common/common_data.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ltm4686 examples.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "no_os_i2c.h"
+#include "ltm4686.h"
+
+#define LTM4686_ADDRESS                         0x4F
+
+extern struct no_os_uart_init_param ltm4686_uart_ip;
+extern struct no_os_i2c_init_param ltm4686_i2c_ip;
+extern struct ltm4686_init_param ltm4686_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ltm4686/src/examples/basic/basic_example.c
+++ b/projects/ltm4686/src/examples/basic/basic_example.c
@@ -1,0 +1,93 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example source file for ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "basic_example.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "ltm4686.h"
+
+int basic_example_main()
+{
+	struct ltm4686_dev *dev;
+	int ret = 0, vals[4];
+	uint8_t chan;
+
+	ret = ltm4686_init(&dev, &ltm4686_ip);
+	if (ret)
+		goto exit;
+
+	ret = ltm4686_set_operation(dev, LTM4686_CHAN_ALL,
+				    LTM4686_OPERATION_ON);
+	if (ret)
+		goto exit;
+
+	ret = ltm4686_pwm_mode(dev, LTM4686_CHAN_ALL,
+			       LTM4686_PWM_FORCED_CONTINUOUS_MODE);
+	if (ret)
+		goto exit;
+
+	while (1) {
+		for (chan = LTM4686_CHAN_0; chan <= LTM4686_CHAN_1; chan++) {
+			ret = ltm4686_read_value(dev, chan, LTM4686_VIN,
+						 &vals[0]);
+			if (ret)
+				goto exit;
+
+			ret = ltm4686_read_value(dev, chan, LTM4686_VOUT,
+						 &vals[1]);
+			if (ret)
+				goto exit;
+
+			ret = ltm4686_read_value(dev, chan, LTM4686_IOUT,
+						 &vals[2]);
+			if (ret)
+				goto exit;
+
+			ret = ltm4686_read_value(dev, chan, LTM4686_TEMP_IC,
+						 &vals[3]);
+			if (ret)
+				goto exit;
+
+			pr_info("vin = %d mV | vout = %d mV | iout = %d mA | temp_ic = %d C\n",
+				vals[0], vals[1], vals[2], vals[3] / 1000);
+		}
+
+		pr_info("\n");
+		no_os_mdelay(500);
+	}
+
+exit:
+	ltm4686_remove(dev);
+
+	return ret;
+}

--- a/projects/ltm4686/src/examples/basic/basic_example.h
+++ b/projects/ltm4686/src/examples/basic/basic_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Basic example header file for ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ltm4686/src/examples/examples_src.mk
+++ b/projects/ltm4686/src/examples/examples_src.mk
@@ -1,0 +1,28 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y, $(strip $(IIOD)))
+LIBRARIES += iio
+SRCS += $(NO-OS)/iio/iio_app/iio_app.c	\
+	$(DRIVERS)/power/ltm4686/iio_ltm4686.c	\
+	$(NO-OS)/iio/iio.c	\
+	$(NO-OS)/iio/iiod.c	\
+	$(NO-OS)/util/no_os_fifo.c
+
+INCS += $(NO-OS)/iio/iio_app/iio_app.h	\
+	$(DRIVERS)/power/ltm4686/iio_ltm4686.h	\
+	$(NO-OS)/iio/iio.h	\
+	$(NO-OS)/iio/iiod.h	\
+	$(NO-OS)/iio/iio_types.h	\
+	$(NO-OS)/include/no_os_fifo.h
+endif

--- a/projects/ltm4686/src/examples/iio_example/iio_example.c
+++ b/projects/ltm4686/src/examples/iio_example/iio_example.c
@@ -1,0 +1,81 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  IIO example source file for ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "iio_example.h"
+#include "iio_ltm4686.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+int iio_example_main()
+{
+	int ret;
+
+	struct ltm4686_iio_desc *ltm4686_iio_desc;
+	struct ltm4686_iio_desc_init_param ltm4686_iio_ip = {
+		.ltm4686_init_param = &ltm4686_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = ltm4686_iio_init(&ltm4686_iio_desc, &ltm4686_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ltm4686",
+			.dev = ltm4686_iio_desc,
+			.dev_descriptor = ltm4686_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ltm4686_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_ltm4686;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio_ltm4686:
+	ltm4686_iio_remove(ltm4686_iio_desc);
+exit:
+	if (ret)
+		pr_err("Error!\n");
+	return ret;
+}

--- a/projects/ltm4686/src/examples/iio_example/iio_example.h
+++ b/projects/ltm4686/src/examples/iio_example/iio_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   iio_example.h
+ *   @brief  IIO example header file for ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/ltm4686/src/platform/maxim/main.c
+++ b/projects/ltm4686/src/platform/maxim/main.c
@@ -1,0 +1,72 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+int main()
+{
+	int ret = -EINVAL;
+
+#ifdef BASIC_EXAMPLE
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &ltm4686_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+	ret = basic_example_main();
+#endif
+
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+#endif
+
+#if (BASIC_EXAMPLE + IIO_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#elif (BASIC_EXAMPLE + IIO_EXAMPLE > 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and rebuild the project.
+#endif
+
+	return ret;
+}

--- a/projects/ltm4686/src/platform/maxim/parameters.c
+++ b/projects/ltm4686/src/platform/maxim/parameters.c
@@ -1,0 +1,41 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param ltm4686_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_i2c_init_param ltm4686_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/ltm4686/src/platform/maxim/parameters.h
+++ b/projects/ltm4686/src/platform/maxim/parameters.h
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_i2c.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID		0
+#endif
+
+#define UART_DEVICE_ID		1
+#define UART_IRQ_ID		UART1_IRQn
+#define UART_BAUDRATE		115200
+#define	UART_OPS		&max_uart_ops
+#define UART_EXTRA		&ltm4686_uart_extra
+
+#define I2C_DEVICE_ID		0
+#define I2C_OPS			&max_i2c_ops
+#define I2C_EXTRA		&ltm4686_i2c_extra
+
+extern struct max_uart_init_param ltm4686_uart_extra;
+extern struct max_i2c_init_param ltm4686_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ltm4686/src/platform/maxim/platform_src.mk
+++ b/projects/ltm4686/src/platform/maxim/platform_src.mk
@@ -1,0 +1,16 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/maxim_irq.h       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.h       \
+        $(PLATFORM_DRIVERS)/maxim_uart.h      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+        $(PLATFORM_DRIVERS)/maxim_gpio.c      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/maxim_irq.c       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.c       \
+        $(PLATFORM_DRIVERS)/maxim_uart.c      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/ltm4686/src/platform/platform_includes.h
+++ b/projects/ltm4686/src/platform/platform_includes.h
@@ -1,0 +1,40 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by ltm4686 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

This adds driver and IIO support for LTM4686, LTM4686B and LTM4673.

The LTM4686 is a dual 10A (12A Peak) or single 20A (24A Peak) step-down
µModule DC/DC regulator with 39ms turn-on time.
The LTM4686B is a dual 14A (17A peak) or single 28A (34A peak) step-down
µModule DC/DC regulator with 39ms turn-on time.
The LTM4673 is a quad output, dual 12A and dual 5A, switching mode DC/DC
step-down μModule regulator.

It features remote configurability and telemetry-monitoring of power
management parameters over PMBus.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
